### PR TITLE
Changes for MOD3.0

### DIFF
--- a/mod_api/static/mod_api/openAPI.yaml
+++ b/mod_api/static/mod_api/openAPI.yaml
@@ -1463,10 +1463,6 @@ components:
               title: more permissions
               description: A related resource which describes additional permissions or alternative licenses for a Work which may be available.
               $ref: "#/components/schemas/rdfsResource"
-            dcat:downloadURL:
-              title: download URL
-              description: The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dcterms:format and/or dcat:mediaType
-              $ref: "#/components/schemas/rdfsResource"
             foaf:primaryTopic:
               title: key classes
               $ref: "#/components/schemas/owlThing"
@@ -1928,10 +1924,6 @@ components:
               title: group
               description: A group of ontologies that the ontology is usually considered into.
               $ref: "#/components/schemas/modGroup"
-            mod:hasEvaluation:
-              title: evaluation
-              description: This property makes a relationship between an ontology and its evaluation result.
-              $ref: "#/components/schemas/modEvaluation"
             mod:knownUsage:
               title: known usage
               description: The applications where the ontology is being used.

--- a/mod_api/static/mod_api/openAPI.yaml
+++ b/mod_api/static/mod_api/openAPI.yaml
@@ -585,18 +585,27 @@ components:
         '@context':
           type: object
           properties:
+            adms:
+              title: adms
+              example: http://www.w3.org/ns/adms#
+            cc:
+              title: cc
+              example: http://creativecommons.org/ns#
             dc:
               title: dc
               example: http://purl.org/dc/elements/1.1/
             dcat:
               title: dcat
               example: http://www.w3.org/ns/dcat#
-            dct:
-              title: dcat
+            dcterms:
+              title: dcterms
               example: http://purl.org/dc/terms/
             dctype:
               title: dct
               example: http://purl.org/dc/dcmitype/
+            doap:
+              title: doap
+              example: http://usefulinc.com/ns/doap/
             foaf:
               title: foaf
               example: http://xmlns.com/foaf/0.1/
@@ -621,18 +630,38 @@ components:
             rdfs:
               title: rdfs
               example: http://www.w3.org/2000/01/rdf-schema#
+            schema:
+              title: schema
+              example: https://schema.org/
+            sd:
+              title: sd
+              example: http://www.w3.org/ns/sparql-service-description#
             skos:
               title: skos
               example: http://www.w3.org/2004/02/skos/core#
             time:
               title: time
               example: http://www.w3.org/2006/time#
+            vann:
+              title: vann
+              example: https://vocab.org/vann/
             vcard:
               title: vcard
               example: http://www.w3.org/2006/vcard/ns#
+            void:
+              title: void
+              example: http://rdfs.org/ns/void#
             xsd:
               title: xsd
               example: http://www.w3.org/2001/XMLSchema#
+
+    admsAsset:
+      type: object
+      properties:
+        '@type':
+          title: Asset
+          description: An Asset is an abstract entity that reflects the intellectual content of the asset and represents those characteristics of the asset that are independent of its physical embodiment. This abstract entity combines the FRBR entities work (a distinct intellectual or artistic creation) and expression (the intellectual or artistic realization of a work). Assets can be versioned. Every time the intellectual content of an asset changes, the result is considered to be a new asset that can be linked to previous and next versions of the Asset. The physical embodiment of an Asset is called an Asset Distribution. A particular Asset may have zero or more Asset Distributions.
+          example: adms:Asset
 
     # see https://www.w3.org/TR/vocab-dcat-2/#Class:Catalog
     dcatCatalog:
@@ -650,7 +679,7 @@ components:
               title: dataset
               description: A collection of data that is listed in the catalog.
               $ref: "#/components/schemas/dcatDataset"
-            dct:hasPart:
+            dcterms:hasPart:
               title: has part
               description: An item that is listed in the catalog.
               $ref: "#/components/schemas/dcatResource"
@@ -682,26 +711,25 @@ components:
       title: Catalog Record
       description: A record in a data catalog, describing the registration of a single dataset or data service.
       allOf:
-        - $ref: '#/components/schemas/dcatResource'
         - type: object
           properties:
-            dct:conformsTo:
+            dcterms:conformsTo:
               title: conforms to
               description: An established standard to which the described resource conforms.
-              $ref: "#/components/schemas/dctStandard" 
-            dct:description:
+              $ref: "#/components/schemas/dctermsStandard" 
+            dcterms:description:
               title: Description
               description: A free-text account of the record.
               $ref: "#/components/schemas/rdfsLiteral"
-            dct:issued:
+            dcterms:issued:
               title: listing date
               description: The date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog.
               $ref: "#/components/schemas/rdfsLiteral"
-            dct:modified:
+            dcterms:modified:
               title: update/modification date
               description: Most recent date on which the catalog entry was changed, updated or modified.
               $ref: "#/components/schemas/rdfsLiteral"
-            dct:title:
+            dcterms:title:
               title: Title
               description: A name given to the resource.
               $ref: "#/components/schemas/rdfsLiteral"
@@ -739,26 +767,26 @@ components:
         - $ref: '#/components/schemas/dcatResource'
         - type: object
           properties:
-            dct:accrualPeriodicity:
+            dcterms:accrualPeriodicity:
               title: frequency
               description: The frequency at which dataset is published.
-              $ref: "#/components/schemas/dctFrequency"
+              $ref: "#/components/schemas/dctermsFrequency"
             dcat:distribution:
               title: dataset distribution
               description: An available distribution of the dataset.
               $ref: "#/components/schemas/dcatDistribution"
-            dct:spatial:
+            dcterms:spatial:
               title: spatial/geographical coverage
               description: The geographical area covered by the dataset.
-              $ref: "#/components/schemas/dctLocation"
+              $ref: "#/components/schemas/dctermsLocation"
             dcat:spatialResolutionInMeters:
               title: spatial resolution
               description: Minimum spatial separation resolvable in a dataset, measured in meters.
               $ref: "#/components/schemas/xsdDecimal"
-            dct:temporal:
+            dcterms:temporal:
               title: temporal coverage
               description: The temporal period that the dataset covers.
-              $ref: "#/components/schemas/dctPeriodOfTime"
+              $ref: "#/components/schemas/dctermsPeriodOfTime"
             dcat:temporalResolution:
               title: temporal resolution
               description: Minimum time period resolvable in the dataset.
@@ -778,10 +806,10 @@ components:
           title: access service
           description: A data service that gives access to the distribution of the dataset
           $ref: "#/components/schemas/dcatDataService"
-        dct:accessRights:
+        dcterms:accessRights:
           title: access rights
           description: A rights statement that concerns how the distribution is accessed.
-          $ref: "#/components/schemas/dctRightsStatement"
+          $ref: "#/components/schemas/dctermsRightsStatement"
         dcat:accessURL:
           title: access URL
           description: A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.
@@ -793,51 +821,51 @@ components:
         dcat:compressFormat:
           title: compression format
           description: The compression format of the distribution in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file.
-          $ref: "#/components/schemas/dctMediaType"
-        dct:conformsTo:
+          $ref: "#/components/schemas/dctermsMediaType"
+        dcterms:conformsTo:
           title: conforms to
           description: An established standard to which the distribution conforms.
-          $ref: "#/components/schemas/dctStandard"
-        dct:description:
+          $ref: "#/components/schemas/dctermsStandard"
+        dcterms:description:
           title: description
           description: A free-text account of the distribution.
           $ref: "#/components/schemas/rdfsLiteral"
         dcat:downloadURL:
           title: download URL
-          description: The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dct:format and/or dcat:mediaType
+          description: The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dcterms:format and/or dcat:mediaType
           $ref: "#/components/schemas/rdfsResource"
-        dct:format:
+        dcterms:format:
           title: format
           description: The file format of the distribution.
-          $ref: "#/components/schemas/dctMediaTypeOrExtent"
+          $ref: "#/components/schemas/dctermsMediaTypeOrExtent"
         odrl:hasPolicy:
           title: has policy
           description: An ODRL conformant policy expressing the rights associated with the distribution.
           $ref: "#/components/schemas/odrlPolicy"
-        dct:issued:
+        dcterms:issued:
           title: release date
           description: Date of formal issuance (e.g., publication) of the distribution.
           $ref: "#/components/schemas/rdfsLiteral"
-        dct:license:
+        dcterms:license:
           title: license
           description: A legal document under which the distribution is made available.
-          $ref: "#/components/schemas/dctLicenseDocument"
+          $ref: "#/components/schemas/dctermsLicenseDocument"
         dcat:mediaType:
           title: media type
           description: The media type of the distribution as defined by IANA.
-          $ref: "#/components/schemas/dctMediaType"
-        dct:modified:
+          $ref: "#/components/schemas/dctermsMediaType"
+        dcterms:modified:
           title: update/modification date
           description: Most recent date on which the distribution was changed, updated or modified.
           $ref: "#/components/schemas/rdfsLiteral"
         dcat:packageFormat:
           title: packaging format
           description: The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.
-          $ref: "#/components/schemas/dctMediaType"
-        dct:rights:
+          $ref: "#/components/schemas/dctermsMediaType"
+        dcterms:rights:
           title: rights
           description: Information about rights held in and over the distribution.
-          $ref: "#/components/schemas/dctRightsStatement"
+          $ref: "#/components/schemas/dctermsRightsStatement"
         dcat:spatialResolutionInMeters:
           title: spatial resolution
           description: The minimum spatial separation resolvable in a dataset distribution, measured in meters.
@@ -846,7 +874,7 @@ components:
           title: temporal resolution
           description: Minimum time period resolvable in the dataset distribution.
           $ref: "#/components/schemas/xsdDuration"
-        dct:title:
+        dcterms:title:
           title: title
           description: A name given to the distribution.
           $ref: "#/components/schemas/rdfsLiteral"
@@ -857,63 +885,63 @@ components:
       description: Resource published or curated by a single agent.
       type: object
       properties:
-        dct:accessRights:
+        dcterms:accessRights:
           title: access rights
           description: Information about who can access the resource or an indication of its security status.
-          $ref: "#/components/schemas/dctRightsStatement"
-        dct:conformsTo:
+          $ref: "#/components/schemas/dctermsRightsStatement"
+        dcterms:conformsTo:
           title: conforms to
           description: An established standard to which the described resource conforms.
-          $ref: "#/components/schemas/dctStandard"
+          $ref: "#/components/schemas/dctermsStandard"
         dcat:contactPoint:
           title: contact point
           description: Relevant contact information for the cataloged resource. Use of vCard is recommended [VCARD-RDF].
           $ref: "#/components/schemas/vcardKind"
-        dct:creator:
+        dcterms:creator:
           title: resource creator
           description: The entity responsible for producing the resource.
           $ref: "#/components/schemas/foafAgent"
-        dct:description:
+        dcterms:description:
           title: description
           description: A free-text account of the item.
-          $ref: "#/components/schemas/dctIdentifier"
+          $ref: "#/components/schemas/dctermsIdentifier"
         odrl:hasPolicy:
           title: has policy
           description: An ODRL conformant policy expressing the rights associated with the resource.
           $ref: "#/components/schemas/odrlPolicy"
-        dct:identifier:
+        dcterms:identifier:
           title: identifier
           description: A unique identifier of the item.
-          $ref: "#/components/schemas/dctIdentifier"
-        dct:isReferencedBy:
+          $ref: "#/components/schemas/dctermsIdentifier"
+        dcterms:isReferencedBy:
           title: is referenced by
           description: A related resource, such as a publication, that references, cites, or otherwise points to the cataloged resource.
-          $ref: "#/components/schemas/dctIsReferencedBy"
-        dct:issued:
+          $ref: "#/components/schemas/dctermsIsReferencedBy"
+        dcterms:issued:
           title: release date
           description: Date of formal issuance (e.g., publication) of the item.
-          $ref: "#/components/schemas/dctIdentifier"
+          $ref: "#/components/schemas/dctermsIdentifier"
         dcat:keyword:
           title:  keyword/tag
           description: A keyword or tag describing the resource.
-          $ref: "#/components/schemas/dctIdentifier"
+          $ref: "#/components/schemas/dctermsIdentifier"
         dcat:landingPage:
           title: landing page
           description: A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information.
           $ref: "#/components/schemas/foafDocument"
-        dct:language:
+        dcterms:language:
           title: language
           description: A language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a cataloged resource (i.e. dataset or service) or the textual values of a dataset distribution
-          $ref: "#/components/schemas/dctLinguisticSystem"
-        dct:license:
+          $ref: "#/components/schemas/dctermsLinguisticSystem"
+        dcterms:license:
           title: license
           description: A legal document under which the resource is made available.
-          $ref: "#/components/schemas/dctLicenseDocument"
-        dct:modified:
+          $ref: "#/components/schemas/dctermsLicenseDocument"
+        dcterms:modified:
           title: update/modification date
           description: Most recent date on which the item was changed, updated or modified.
-          $ref: "#/components/schemas/dctIdentifier"
-        dct:publisher:
+          $ref: "#/components/schemas/rdfsLiteral"
+        dcterms:publisher:
           title: publisher
           descrip#tion: The entity responsible for making the item available.
           $ref: "#/components/schemas/foafAgent"
@@ -925,28 +953,68 @@ components:
           title: qualified relation
           description: Link to a description of a relationship with another resource.
           $ref: "#/components/schemas/dcatResource"
-        dct:relation:
+        dcterms:relation:
           title: resource relation
           description: A resource with an unspecified relationship to the cataloged item.
-          $ref: "#/components/schemas/dctRelation"
-        dct:rights:
+          $ref: "#/components/schemas/dctermsRelation"
+        dcterms:rights:
           title: rights
-          description: A statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements.
-          $ref: "#/components/schemas/dctRightsStatement"
-        dcat:theme:
+          description: A statement that concerns all rights not addressed with dcterms:license or dcterms:accessRights, such as copyright statements.
+          $ref: "#/components/schemas/dctermsRightsStatement"
+        dcterms:subject:
           title: theme/category
           description: A main category of the resource. A resource can have multiple themes.
           $ref: "#/components/schemas/skosConcept"
-        dct:title:
+        dcterms:title:
           title: title
           description: A name given to the item.
-          $ref: "#/components/schemas/dctIdentifier"
-        dct:type:
+          $ref: "#/components/schemas/dctermsIdentifier"
+        dcterms:type:
           title: type/genre
           description: The nature or genre of the resource.
           $ref: "#/components/schemas/dcType"
 
-    dctAgent:
+    dctermsAbstract:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/abstract/abstractID
+        '@type':
+          title: Abstract
+          description: A summary of the resource
+          example: dcterms:abstract
+
+    dctermsAccrualMethod:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/accrualMethod/accrualMethodID
+        '@type':
+          title: Accrual Method
+          description: The method by which items are added to a collection.
+          example: dcterms:accrualMethod
+
+    dctermsAccrualPeriodicity:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/accrualPeriodicity/accrualPeriodicityID
+        '@type':
+          title: Accrual Periodicity
+          description: The frequency with which items are added to a collection.
+          example: dcterms:accrualPeriodicity
+
+    dctermsAccrualPolicy:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/accrualPolicy/accrualPolicy
+        '@type':
+          title: Accrual Policy
+          description: The policy governing the addition of items to a collection.
+          example: dcterms:accrualPolicy
+
+    dctermsAgent:
       type: object
       properties:
         '@id':
@@ -954,9 +1022,39 @@ components:
         '@type':
           title: Agent
           description: A resource that acts or has the power to act.
-          example: dct:Agent
+          example: dcterms:Agent
 
-    dctFrequency:
+    dctermsAudience:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/audience/audienceID
+        '@type':
+          title: Audience
+          description: AA class of agents for whom the resource is intended or useful.
+          example: dcterms:audience
+
+    dctermsContributor:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/contributor/contributorID
+        '@type':
+          title: Contributor
+          description: An entity responsible for making contributions to the resource.
+          example: dcterms:contributor
+
+    dctermsCoverage:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/coverage/coverageID
+        '@type':
+          title: Coverage
+          description: The spatial or temporal topic of the resource, spatial applicability of the resource, or jurisdiction under which the resource is relevant.
+          example: dcterms:coverage
+
+    dctermsFrequency:
       type: object
       properties:
         '@id':
@@ -964,9 +1062,39 @@ components:
         '@type':
           title: Frequency
           description: A rate at which something recurs.
-          example: dct:Frequency
+          example: dcterms:Frequency
 
-    dctIdentifier:
+    dctermsHasFormat:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/hasFormat/hasFormatID
+        '@type':
+          title: Has Format
+          description: A related resource that is substantially the same as the pre-existing described resource, but in another format.
+          example: dcterms:hasFormat
+
+    dctermsHasPart:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/hasPart/hasPartID
+        '@type':
+          title: Has Part
+          description: A related resource that is included either physically or logically in the described resource.
+          example: dcterms:hasPart
+
+    dctermsHasVersion:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/hasVersion/hasVersionID
+        '@type':
+          title: Has Version
+          description: A related resource that is a version, edition, or adaptation of the described resource.
+          example: dcterms:hasVersion
+
+    dctermsIdentifier:
       type: object
       properties:
         '@id':
@@ -974,9 +1102,29 @@ components:
         '@type':
           title: Identifier
           description: An unambiguous reference to the resource within a given context.
-          example: dct:identifier
+          example: dcterms:identifier
 
-    dctIsReferencedBy:
+    dctermsIsFormatOf:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/isFormatOf/isFormatOfID
+        '@type':
+          title: Is Format Of
+          description: A pre-existing related resource that is substantially the same as the described resource, but in another format.
+          example: dcterms:isFormatOf
+
+    dctermsIsPartOf:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/isPartOf/isPartOfID
+        '@type':
+          title: Is Part Of
+          description: A related resource in which the described resource is physically or logically included.
+          example: dcterms:isPartOf
+
+    dctermsIsReferencedBy:
       type: object
       properties:
         '@id':
@@ -984,9 +1132,9 @@ components:
         '@type':
           title: Is Referenced By
           description: A related resource that references, cites, or otherwise points to the described resource.
-          example: dct:isReferencedBy
+          example: dcterms:isReferencedBy
 
-    dctLicenseDocument:
+    dctermsLicenseDocument:
       type: object
       properties:
         '@id':
@@ -994,9 +1142,9 @@ components:
         '@type':
           title: License Document
           description: A legal document giving official permission to do something with a resource.
-          example: dct:LicenseDocument
+          example: dcterms:LicenseDocument
 
-    dctLocation:
+    dctermsLocation:
       type: object
       properties:
         '@id':
@@ -1004,9 +1152,9 @@ components:
         '@type':
           title: Location
           description: A spatial region or named place.
-          example: dct:Location
+          example: dcterms:Location
 
-    dctLinguisticSystem:
+    dctermsLinguisticSystem:
       type: object
       properties:
         '@id':
@@ -1014,9 +1162,9 @@ components:
         '@type':
           title: Linguistic System
           description: A system of signs, symbols, sounds, gestures, or rules used in communication.
-          example: dct:LinguisticSystem
+          example: dcterms:LinguisticSystem
 
-    dctMediaType:
+    dctermsMediaType:
       type: object
       properties:
         '@id':
@@ -1024,9 +1172,9 @@ components:
         '@type':
           title: Media Type
           description: A file format or physical medium.
-          example: dct:MediaType
+          example: dcterms:MediaType
 
-    dctMediaTypeOrExtent:
+    dctermsMediaTypeOrExtent:
       type: object
       properties:
         '@id':
@@ -1034,9 +1182,9 @@ components:
         '@type':
           title: Media Type or Extent
           description: A media type or extent.
-          example: dct:MediaTypeOrExtent
+          example: dcterms:MediaTypeOrExtent
 
-    dctPeriodOfTime:
+    dctermsPeriodOfTime:
       type: object
       properties:
         '@id':
@@ -1044,9 +1192,9 @@ components:
         '@type':
           title: Period of Time
           description: An interval of time that is named or defined by its start and end dates.
-          example: dct:PeriodOfTime
+          example: dcterms:PeriodOfTime
 
-    dctRelation:
+    dctermsRelation:
       type: object
       properties:
         '@id':
@@ -1054,9 +1202,19 @@ components:
         '@type':
           title: Relation
           description: A related resource.
-          example: dct:relation
+          example: dcterms:relation
 
-    dctRightsStatement:
+    dctermsRightsHolder:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/RightsHolder/RightsHolderID
+        '@type':
+          title: rights holder
+          description: The person who can be contacted to enquire about an ontology.
+          example: dcterms:RightsHolder
+
+    dctermsRightsStatement:
       type: object
       properties:
         '@id':
@@ -1064,9 +1222,19 @@ components:
         '@type':
           title: Rights Statement
           description: A statement about the intellectual property rights (IPR) held in or over a resource, a legal document giving official permission to do something with a resource, or a statement about access rights.
-          example: dct:RightsStatement
+          example: dcterms:RightsStatement
 
-    dctStandard:
+    dctermsSource:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/source/sourceID
+        '@type':
+          title: Source
+          description: A related resource from which the described resource is derived.
+          example: dcterms:source
+
+    dctermsStandard:
       type: object
       properties:
         '@id':
@@ -1074,7 +1242,7 @@ components:
         '@type':
           title: Standard
           description: A reference point against which other things can be evaluated or compared.
-          example: dct:Standard
+          example: dcterms:Standard
 
     dcType:
       type: object
@@ -1085,6 +1253,36 @@ components:
           title: Type
           description: The nature or genre of the resource.
           example: dt:type
+
+    doapBugDatabase:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/bug-database/bug-databaseID
+        '@type':
+          title: bug database
+          description: Bug tracker for a project.
+          example: doap:bug-database
+
+    doapMailingList:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/doapMailingList/doapMailingListID
+        '@type':
+          title: mailing list
+          description: Mailing list home page or email address.
+          example: doap:mailing-list
+
+    doapRepository:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/repository/repositoryID
+        '@type':
+          title: Repository
+          description: Source code repository.
+          example: doap:repository
 
     foafAgent:
       type: object
@@ -1106,6 +1304,16 @@ components:
           description: A document.
           example: foaf:Document
 
+    foafImage:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/Image/ImageID
+        '@type':
+          title: Image
+          description: An image.
+          example: foaf:Image
+
     foafProject:
       type: object
       properties:
@@ -1116,6 +1324,15 @@ components:
           description: The Project class represents the class of things that are 'projects'. These may be formal or informal, collective or individual. It is often useful to indicate the homepage of a Project.
           example: foaf:Project
 
+    icalVtodo:
+      type: object
+      properties:
+        '@id':
+          example: https://example.org/Vtodo/VtodoID
+        '@type':
+          title: VTODO
+          description: Provide a grouping of calendar properties that describe a to-do.
+
     modAnalytics:
       type: object
       properties:
@@ -1125,6 +1342,14 @@ components:
           type: array
           items:
             example: mod:Analytics
+
+    modComesFromTheSameDomain:
+      type: object
+      properties:
+        '@type':
+          title: comes from the same domain
+          description: If the two ontologies come from the same domain (without any other details).
+          example: mod:comesFromTheSameDomain
 
     modEngineeringMethodology:
       title: Semantic Artefact Engineering Methodology
@@ -1150,7 +1375,7 @@ components:
             example: mod:Evaluation
 
     modFairAssessment:
-      title: FAIRness assessment"
+      title: FAIRness assessment
       type: object
       properties:
         '@id':
@@ -1159,6 +1384,14 @@ components:
           type: array
           items:
             example: mod:FairAssessment
+
+    modGeneralizes:
+      type: object
+      properties:
+        '@type':
+          title: generalizes
+          description: Indicates that the subject vocabulary generalizes by some superclasses or superproperties the object vocabulary.
+          example: mod:generalizes
 
     modGroup:
       title: Semantic Artefact Group
@@ -1171,6 +1404,30 @@ components:
           type: array
           items:
             example: mod:Group
+
+    modHasDisjunctionsWith:
+      type: object
+      properties:
+        '@type':
+          title: has disjunctions with
+          description:  Indicates that the subject vocabulary declares some disjunct classes with the object vocabulary.
+          example: mod:hasDisjunctionsWith
+
+    modHasDisparateModelling:
+      type: object
+      properties:
+        '@type':
+          title: disparate modelling with
+          description: Disagreements related  to  the  conceptualization  of  the  ontologies. Two ontologies are considered to have disparate modeling if they represent corresponding entities in different ways, e.g.  as an instance in one case and a class in the other.
+          example: mod:hasDisparateModelling
+
+    modHasEquivalencesWith:
+      type: object
+      properties:
+        '@type':
+          title: has equivalences with
+          description: Indicates that the subject vocabulary declares some equivalent classes or properties with the object vocabulary.
+          example: mod:hasEquivalencesWith
 
     modKnowledgeRepresentationParadigm:
       title: Knowledge Representation Paradigm
@@ -1198,6 +1455,113 @@ components:
         -  $ref: '#/components/schemas/dcatResource'
         - type: object
           properties:
+            cc:useGuidelines:
+              title: use guidelines
+              description: A related resource which defines non-binding use guidelines for the work.
+              $ref: "#/components/schemas/rdfsResource"
+            cc:morePermissions:
+              title: more permissions
+              description: A related resource which describes additional permissions or alternative licenses for a Work which may be available.
+              $ref: "#/components/schemas/rdfsResource"
+            dcat:downloadURL:
+              title: download URL
+              description: The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dcterms:format and/or dcat:mediaType
+              $ref: "#/components/schemas/rdfsResource"
+            foaf:primaryTopic:
+              title: key classes
+              $ref: "#/components/schemas/owlThing"
+            dcterms:abstract:
+              title: abstract
+              description: A summary of the resource.
+              $ref: "#/components/schemas/dctermsAbstract"
+            dcterms:accrualMethod:
+              title: accrual method
+              description: The method by which items are added to a collection. Recommended practice is to use a value from the Collection Description Accrual Method Vocabulary.
+              $ref: "#/components/schemas/dctermsAccrualMethod"
+            dcterms:accrualPeriodicity:
+              title: accrual periodicity
+              description: The frequency with which items are added to a collection. Recommended practice is to use a value from the Collection Description Frequency Vocabulary.
+              $ref: "#/components/schemas/dctermsAccrualPeriodicity"
+            dcterms:accrualPolicy:
+              title: accrual policy
+              description: The policy governing the addition of items to a collection. Recommended practice is to use a value from the Collection Description Accrual Policy Vocabulary.
+              $ref: "#/components/schemas/dctermsAccrualPolicy"
+            dcterms:alternative:
+              title: alternative name
+              description: An alternative name for the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:audience:
+              title: target audience
+              description: A class of agents for whom the resource is intended or useful.
+              $ref: "#/components/schemas/dctermsAudience"
+            dcterms:bibliographicCitation:
+              title: bibliographic reference
+              description: A bibliographic reference for the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:contributor:
+              title: contributor
+              description: An entity responsible for making contributions to the resource.
+              $ref: "#/components/schemas/dctermsContributor"
+            dcterms:coverage:
+              title: coverage
+              description: The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant. Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names [[TGN](https://www.getty.edu/research/tools/vocabulary/tgn/index.html)]. Where appropriate, named places or time periods may be used in preference to numeric identifiers such as sets of coordinates or date ranges.  Because coverage is so broadly defined, it is preferable to use the more specific subproperties Temporal Coverage and Spatial Coverage.
+              $ref: "#/components/schemas/dctermsCoverage"
+            dcterms:hasFormat:
+              title: has format
+              description: A related resource that is substantially the same as the pre-existing described resource, but in another format.
+              $ref: "#/components/schemas/dctermsHasFormat"
+            dcterms:hasPart:
+              title: has part (has view)
+              description: A related resource that is included either physically or logically in the described resource.
+              $ref: "#/components/schemas/dctermsHasPart"
+            dcterms:hasVersion:
+              title: has version
+              description: A related ontology that is a version, edition, or adtapation of the described ontology.
+              $ref: "#/components/schemas/dctermsHasVersion"
+            dcterms:isFormatOf:
+              title: is format of
+              description: A related resource that is substantially the same as the described resource, but in another format.
+              $ref: "#/components/schemas/dctermsIsFormatOf"
+            dcterms:isPartOf:
+              title: is part of (view of)
+              description: Shall be used to identify a subset or a view of an ontology.
+              $ref: "#/components/schemas/dctermsIsPartOf"
+            dcterms:rightsHolder:
+              title: rights holder
+              description: The person who can be contacted to enquire about an ontology.
+              $ref: "#/components/schemas/dctermsRightsHolder"
+            dcterms:source:
+              title: source
+              description: SThe ontology(ies) referred to while creating the present ontology.
+              $ref: "#/components/schemas/dctermsSource"
+            doap:bug-database:
+              title: bug database
+              description: Bug tracker for a project.
+              $ref: "#/components/schemas/doapBugDatabase"
+            doap:mailing-list:
+              title: 
+              description: 
+              $ref: "#/components/schemas/doapMailingList"
+            doap:repository:
+              title: repository
+              description: Source code repository.
+              $ref: "#/components/schemas/doapRepository"
+            foaf:depiction:
+              title: depiction
+              description: A depiction of some thing.
+              $ref: "#/components/schemas/foafImage"
+            foaf:fundedBy:
+              title: funded or sponsored by
+              description: An ontology that is sponsored by and developed under a project.
+              $ref: "#/components/schemas/owlThing"
+            foaf:homepage:
+              title: homepage
+              description: An unambiguous reference to the resource within a given context.
+              $ref: "#/components/schemas/foafDocument"
+            foaf:logo:
+              title: logo
+              description: A logo representing some thing.
+              $ref: "#/components/schemas/owlThing"
             mod:acronym:
               title: acronym
               description: Short acronym label, often used as an identifier within some ontology platforms such as BioPortal or OBO Foundry.
@@ -1206,6 +1570,10 @@ components:
               title: analytics
               description: This property shall be used to store any analytics for an ontology. E.g., number of visits an ontology received in a portal, number of downloads, etc.
               $ref: "#/components/schemas/modAnalytics"
+            mod:comesFromTheSameDomain:
+              title: comes from the same domain
+              description: If the two ontologies come from the same domain (without any other details).
+              $ref: "#/components/schemas/modComesFromTheSameDomain"
             mod:competencyQuestion:
               title: competency question
               description: A set of questions made to build an ontology at the design time.
@@ -1217,19 +1585,31 @@ components:
             mod:endorsedBy:
               title: endorsed by
               description: An ontology endorsed by an agent.
-              $ref: "#/components/schemas/dctAgent"
+              $ref: "#/components/schemas/dctermsAgent"
+            mod:generalizes:
+              title: generalizes
+              description: Indicates that the subject vocabulary generalizes by some superclasses or superproperties the object vocabulary.
+              $ref: "#/components/schemas/modGeneralizes"
             mod:group:
               title: group
               description: A group of ontologies that the ontology is usually considered into.
               $ref: "#/components/schemas/modGroup"
+            mod:hasDisjunctionsWith:
+              title: has disjunctions with
+              description: Indicates that the subject vocabulary declares some disjunct classes with the object vocabulary.
+              $ref: "#/components/schemas/modHasDisjunctionsWith"
+            mod:hasDisparateModelling:
+              title: disparate modelling with
+              description: Disagreements related  to  the  conceptualization  of  the  ontologies. Two ontologies are considered to have disparate modeling if they represent corresponding entities in different ways, e.g.  as an instance in one case and a class in the other.
+              $ref: "#/components/schemas/modHasDisparateModelling"
+            mod:hasEquivalencesWith:
+              title: has equivalences with
+              description: Indicates that the subject vocabulary declares some equivalent classes or properties with the object vocabulary.
+              $ref: "#/components/schemas/modHasEquivalencesWith"
             mod:hasEvaluation:
               title: evaluation
               description: This property makes a relationship between an ontology and its evaluation result.
               $ref: "#/components/schemas/modEvaluation"
-            mod:hasFormalityLevel:
-              title: formality level
-              description: The level of formality of an ontology.
-              $ref: "#/components/schemas/xsdString"
             mod:knownUsage:
               title: known usage
               description: The applications where the ontology is being used.
@@ -1238,7 +1618,11 @@ components:
               title: metrics
               description: A generic property to store any metrics (number) related to the ontology.
               $ref: "#/components/schemas/xsdNonNegativeInteger"
-            mod:numberOfEnsorments:
+            mod:numberOfAgents:
+              title: number of agents
+              description: Total number of agents in a semantic artefact catalogue or number of agents related a given semantic artefact.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfEndorsements:
               title: number of endorsmements
               description: Number of endorsing organizations (maybe represented with mod:endorsedBy).
               $ref: "#/components/schemas/xsdNonNegativeInteger"
@@ -1250,25 +1634,173 @@ components:
               title: number of notes or comments
               description: Number of notes or comments (maybe represented with schema:comment) related to the ontologies.
               $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfUsers:
+              title: number of users
+              description: Total number of users in a semantic artefact catalogue or number of users watching/following/using a given semantic artefact.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
             mod:numberOfUsingProjects:
               title: number of using projects
               description: Number of projects (maybe represented with mod:usedInProject) using an ontology.
               $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:reliesOn:
+              title: relies on or reuses
+              description: A general property for different kind of case when a semantic resource relies or reuses another one.
+              $ref: "#/components/schemas/modReliesOn"
             mod:semanticArtefactRelation:
               title: generally related to
               description: A general property for semantic artefact relations.
               $ref: "#/components/schemas/modSemanticArtefact"
+            mod:similar:
+              title: similar
+              description: Used to assert that two vocabularies are similar in scope and objectives, independently of the fact that they otherwise refer to each other.
+              $ref: "#/components/schemas/modSimilar"
+            mod:specializes:
+              title: specializes
+              description: Indicates that the subject vocabulary defines some subclasses or subproperties of the object vocabulary, or local restrictions on those.
+              $ref: "#/components/schemas/modSpecializes"
             mod:status:
               title: status
               $ref: "#/components/schemas/xsdString"
+            mod:toDoList:
+              title: to-do list
+              description: Describes future tasks planned by a resource curator. This property is primarily intended to be used for vocabularies or datasets, but the domain is left open, it can be used for any resource. Use iCalendar Vtodo class and its properties to further describe the task calendar, priorities etc.
+              $ref: "#/components/schemas/icalVtodo"
             mod:URI:
               title: URI
               description: The URI of the ontology which is described by this metadata.
               $ref: "#/components/schemas/xsdAnyURI"
+            mod:usedBy:
+              title: used by
+              description: Indicates that the subject vocabulary is used by the object vocabulary.
+              $ref: "#/components/schemas/modUsedBy"
             mod:usedInProject:
               title: used in project
               description: An ontology that is used in a project.      
-              $ref: "#/components/schemas/foafProject"
+              $ref: "#/components/schemas/modUsedInProject"
+            owl:backwardCompatibleWith:
+              title: backward compatible
+              description: This identifies the specified ontology as a prior version of the containing ontology, and further indicates that it is backward compatible with it.
+              $ref: "#/components/schemas/owlOntology"
+            owl:deprecated:
+              title: deprecated
+              description: The annotation property that indicates that a given entity has been deprecated.   
+              $ref: "#/components/schemas/rdfsResource"
+            owl:incompatibleWith:
+              title: incompatible
+              description: This indicates that the containing ontology is a later version of the referenced ontology, but is not backward compatible with it.
+              $ref: "#/components/schemas/owlOntology"
+            owl:priorVersion:
+              title: prior version
+              description: This identifies the specified ontology as a prior version of the containing ontology.
+              $ref: "#/components/schemas/owlOntology"
+            owl:versionInfo:
+              title: version information
+              description: The version of the released ontology.   
+              $ref: "#/components/schemas/rdfsResource"
+            owl:versionIRI:
+              title: version IRI
+              description: The property that identifies the version IRI of an ontology.      
+              $ref: "#/components/schemas/owlOntology"
+            pav:curatedBy:
+              title: curator
+              description: A curator who restructure the previously authored content and shape it to be appropriate for the intended representation (e.g. by normalizing the fields for being represented in a spreadsheet).
+              $ref: "#/components/schemas/pavCuratedBy"
+            pav:createdWith:
+              title: created with
+              description: The tool used for the creation of an ontology.
+              $ref: "#/components/schemas/pavCreatedWith"
+            prov:wasGeneratedBy:
+              title: was generated by
+              description: Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation.
+              $ref: "#/components/schemas/provActivity"
+            prov:wasInvalidatedBy:
+              title: was invalidated by
+              description: Invalidation is the start of the destruction, cessation, or expiry of an existing entity by an activity. The entity is no longer available for use (or further invalidation) after invalidation. Any generation or usage of an entity precedes its invalidation."@en ;
+              $ref: "#/components/schemas/provActivity"
+            rdfs:comment:
+              title: notes or comments
+              description: A description of the subject resource.      
+              $ref: "#/components/schemas/rdfsLiteral"
+            schema:associatedMedia:
+              title:
+              description: A media object that encodes this CreativeWork. This property is a synonym for encoding.      
+              $ref: "#/components/schemas/schemaAssociatedMedia"
+            schema:award:
+              title: award
+              description: An award won by or for this item.
+              $ref: "#/components/schemas/schemaAward"
+            schema:comment:
+              title: user notes or reviews
+              description: Comments, typically from users.
+              $ref: "#/components/schemas/schemaComment"
+            schema:funding:
+              title: funding
+              description: A Grant that directly or indirectly provide funding or sponsorship for this item.
+              $ref: "#/components/schemas/schemaFunding"
+            schema:includedInDataCatalog:
+              title: indexed or included in catalog or repository
+              description: A data catalog which contains this dataset.
+              $ref: "#/components/schemas/schemaIncludedInDataCatalog"
+            schema:translationOfWork:
+              title: translation of
+              description: The work that this work has been translated from.
+              $ref: "#/components/schemas/schemaTranslationOfWork"
+            schema:translator:
+              title: translator
+              description: Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
+              $ref: "#/components/schemas/schemaTranslator"
+            schema:workTranslation:
+              title: work translation
+              description: A pointer to the translated ontology(ies) for an existing ontology.
+              $ref: "#/components/schemas/schemaWorkTranslation"
+            skos:hiddenLabel:
+              title: hidden label
+              description: Hidden or past name.   
+              $ref: "#/components/schemas/rdfsLiteral"
+            vann:changes:
+              title: Changes
+              description: A reference to a resource that describes changes between this version of a vocabulary and the previous.
+              $ref: "#/components/schemas/vannChanges"
+            vann:example:
+              title: example
+              description: A reference to a resource that provides an example of how this resource can be used.
+              $ref: "#/components/schemas/vannExample"
+            vann:preferredNamespacePrefix:
+              title: Preferred Namespace Prefix
+              description: The preferred namespace prefix to use when using terms from this vocabulary in an XML document
+              $ref: "#/components/schemas/vannPreferredNamespacePrefix"
+            vann:preferredNamespaceUri:
+              title: Preferred Namespace Uri
+              description: The preferred namespace URI to use when using terms from this vocabulary in an XML document
+              $ref: "#/components/schemas/vannPreferredNamespaceUri"
+            void:openSearchDescription:
+              title: free-text search endpoint
+              description: An OpenSearch description document for a free-text search service over a void:Dataset.
+              $ref: "#/components/schemas/foafDocument"
+            void:classPartition:
+              title: class partition
+              description: A subset of a void:Dataset that contains only the entities of a certain rdfs:Class.
+              $ref: "#/components/schemas/voidDataset"
+            void:exampleResource:
+              title: example resource
+              description: Example resource of dataset.
+              $ref: "#/components/schemas/rdfsResource"
+            void:rootResource:
+              title: root resource
+              description: This property is to provide the root class(es) of an ontology. This is automatically populated by taking the direct subclasses of owl:Thing. If the ontology is also defined as a unique skos:ConceptScheme, then this property should become equivalent of skos:hasTopConcept.
+              $ref: "#/components/schemas/rdfsResource"
+            void:propertyPartition:
+              title: property partition
+              description: A subset of a void:Dataset that contains only the triples of a certain rdf:Property.
+              $ref: "#/components/schemas/voidDataset"
+            void:uriLookupEndpoint:
+              title: URI lookup endpoint
+              description: A protocol endpoint for simple URI lookups for a void:Dataset.
+              $ref: "#/components/schemas/xsdAnyURI"
+            void:uriRegexPattern:
+              title: identifier pattern
+              description: A regular expression that matches the URIs of a void:Dataset's entities.
+              $ref: "#/components/schemas/voidUriRegexPattern"
 
     modSemanticArtefactCatalog:
       title: Semantic Artfeact Catalog
@@ -1283,6 +1815,288 @@ components:
               items:
                 example: mod:SemanticArtefactCatalog
         - $ref: '#/components/schemas/dcatCatalog'
+        - type: object
+          properties:
+            adms:supportedSchema:
+              title: supported schema/format
+              description: A schema according to which the Asset Repository can provide data about its content.
+              $ref: "#/components/schemas/admsAsset"
+            cc:useGuidelines:
+              title: use guidelines
+              description: A related resource which defines non-binding use guidelines for the work.
+              $ref: "#/components/schemas/rdfsResource"
+            cc:morePermissions:
+              title: more permissions
+              description: A related resource which describes additional permissions or alternative licenses for a Work which may be available.
+              $ref: "#/components/schemas/rdfsResource"
+            dcat:accessURL:
+              title: access URL
+              description: A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.
+              $ref: "#/components/schemas/rdfsResource"
+            dcterms:abstract:
+              title: abstract
+              description: A summary of the resource.
+              $ref: "#/components/schemas/dctermsAbstract"
+            dcterms:accrualMethod:
+              title: accrual method
+              description: The method by which items are added to a collection. Recommended practice is to use a value from the Collection Description Accrual Method Vocabulary.
+              $ref: "#/components/schemas/dctermsAccrualMethod"
+            dcterms:accrualPeriodicity:
+              title: accrual periodicity
+              description: The frequency with which items are added to a collection. Recommended practice is to use a value from the Collection Description Frequency Vocabulary.
+              $ref: "#/components/schemas/dctermsAccrualPeriodicity"
+            dcterms:accrualPolicy:
+              title: accrual policy
+              description: The policy governing the addition of items to a collection. Recommended practice is to use a value from the Collection Description Accrual Policy Vocabulary.
+              $ref: "#/components/schemas/dctermsAccrualPolicy"
+            dcterms:alternative:
+              title: alternative title
+              description: An alternative name for the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:audience:
+              title: target audience
+              description: A class of agents for whom the resource is intended or useful.
+            dcterms:bibliographicCitation:
+              title: bibliographic reference
+              description: A bibliographic reference for the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:created:
+              title: creation date
+              description: Date of creation of the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:contributor:
+              title: contributor
+              description: An entity responsible for making contributions to the resource.
+              $ref: "#/components/schemas/dctermsContributor"
+            dcterms:coverage:
+              title: coverage
+              description: The spatial or temporal topic of the resource, the spatial applicability of the resource, or the jurisdiction under which the resource is relevant. Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names [[TGN](https://www.getty.edu/research/tools/vocabulary/tgn/index.html)]. Where appropriate, named places or time periods may be used in preference to numeric identifiers such as sets of coordinates or date ranges.  Because coverage is so broadly defined, it is preferable to use the more specific subproperties Temporal Coverage and Spatial Coverage.
+              $ref: "#/components/schemas/dctermsCoverage"
+            dcterms:isPartOf:
+              title: is part of (view of)
+              description: Shall be used to identify a subset or a view of an ontology
+              $ref: "#/components/schemas/dctermsIsPartOf"
+            dcterms:modified:
+              title: modification date
+              description: Date on which the resource was changed.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:rightsHolder:
+              title: rights holder
+              description: The person who can be contacted to enquire about an ontology.
+              $ref: "#/components/schemas/dctermsRightsHolder"
+            dcterms:source:
+              title: source
+              description: The ontology(ies) referred to while creating the present ontology.
+              $ref: "#/components/schemas/dctermsSource"
+            doap:bug-database:
+              title: bug database
+              description: Bug tracker for a project.
+              $ref: "#/components/schemas/doapBugDatabase"
+            doap:mailing-list:
+              title: 
+              description: 
+              $ref: "#/components/schemas/doapMailingList"
+            doap:repository:
+              title: repository
+              description: Source code repository.
+              $ref: "#/components/schemas/doapRepository"
+            foaf:depiction:
+              title: depiction
+              description: A depiction of some thing.
+              $ref: "#/components/schemas/foafImage"
+            foaf:fundedBy:
+              title: funded or sponsored by
+              description: An ontology that is sponsored by and developed under a project.
+              $ref: "#/components/schemas/owlThing"
+            foaf:logo:
+              title: logo
+              description: A logo representing some thing.
+              $ref: "#/components/schemas/owlThing"
+            mod:analytics:
+              title: analytics
+              description: This property shall be used to store any analytics for an ontology. E.g., number of visits an ontology received in a portal, number of downloads, etc.
+              $ref: "#/components/schemas/modAnalytics"
+            mod:endorsedBy:
+              title: endorsed by
+              description: An ontology endorsed by an agent.
+              $ref: "#/components/schemas/dctermsAgent"
+            mod:fairScore:
+              title: FAIR assessment
+              description: A FAIRness assessment result produced by a known or identified FAIRness assessment method or tool. It can be either a simple number or a structured result document explaining the assessment.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:group:
+              title: group
+              description: A group of ontologies that the ontology is usually considered into.
+              $ref: "#/components/schemas/modGroup"
+            mod:hasEvaluation:
+              title: evaluation
+              description: This property makes a relationship between an ontology and its evaluation result.
+              $ref: "#/components/schemas/modEvaluation"
+            mod:knownUsage:
+              title: known usage
+              description: The applications where the ontology is being used.
+              $ref: "#/components/schemas/xsdString"
+            mod:metadataVoc:
+              title: metadata vocabulary used
+              $ref: "#/components/schemas/xsdAnyURI"
+            mod:metrics:
+              title: metrics
+              description: A generic property to store any metrics (number) related to the ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfAgents:
+              title: number of agents
+              description: Total number of agents in a semantic artefact catalogue or number of agents related a given semantic artefact.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfArtefacts:
+              title: number of semantic artefacts
+              description: Total number of semantic artefacts within a catalog.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfAxioms:
+              title: number of axioms or triples
+              description: The total number of axioms in an ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfClasses:
+              title: number of classes
+              description: The total number of classes in an ontology.
+              type: integer
+            mod:numberOfDataProperties:
+              title: number of data properties
+              description: The total number of data properties in an ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfDeprecated:
+              title: number of deprecated objects
+              description: The total number of  in an ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfEndorsements:
+              title: number of endorsmements
+              description: Number of endorsing organizations (maybe represented with mod:endorsedBy).
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfIndividuals:
+              title: number of individuals
+              description: The total number of individuals in an ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfLabels:
+              title: number of labels
+              description: Number of defined labels for any resources in an ontology (classes, properties, etc).
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfMappings:
+              title: number of mappings
+              description: Number of mappings within a given semantic artefact or semantic artefact catalogue.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfObjectProperties:
+              title: number of object properties
+              description: The total number of object properties in an ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfProperties:
+              title: number of properties
+              description: The total number of properties in an ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfUsers:
+              title: number of users
+              description: Total number of users in a semantic artefact catalogue or number of users watching/following/using a given semantic artefact.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfUsingProjects:
+              title: number of using projects
+              description: Number of projects (maybe represented with mod:usedInProject) using an ontology.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:toDoList:
+              title: to-do list
+              description: Describes future tasks planned by a resource curator. This property is primarily intended to be used for vocabularies or datasets, but the domain is left open, it can be used for any resource. Use iCalendar Vtodo class and its properties to further describe the task calendar, priorities etc.
+              $ref: "#/components/schemas/icalVtodo"
+            mod:status:
+              title: status
+              $ref: "#/components/schemas/xsdString"
+            mod:usedInProject:
+              title: used in project
+              description: An ontology that is used in a project.      
+              $ref: "#/components/schemas/modUsedInProject"
+            owl:deprecated:
+              title: deprecated
+              description: The annotation property that indicates that a given entity has been deprecated.   
+              $ref: "#/components/schemas/rdfsResource"
+            owl:versionInfo:
+              title: version information
+              description: The version of the released ontology.   
+              $ref: "#/components/schemas/rdfsResource"
+            pav:curatedOn:
+              title: curation date
+              $ref: "#/components/schemas/xsdDate"
+            pav:curatedBy:
+              title: curator
+              description: A curator who restructure the previously authored content and shape it to be appropriate for the intended representation (e.g. by normalizing the fields for being represented in a spreadsheet).
+              $ref: "#/components/schemas/pavCuratedBy"
+            pav:createdWith:
+              title: created with
+              description: The tool used for the creation of an ontology.
+              $ref: "#/components/schemas/pavCreatedWith"
+            prov:wasGeneratedBy:
+              title: was generated by
+              description: Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation.
+              $ref: "#/components/schemas/provActivity"
+            rdfs:comment:
+              title: notes or comments
+              description: A description of the subject resource.      
+              $ref: "#/components/schemas/rdfsLiteral"
+            schema:associatedMedia:
+              title:
+              description: A media object that encodes this CreativeWork. This property is a synonym for encoding.      
+              $ref: "#/components/schemas/schemaAssociatedMedia"
+            schema:award:
+              title: award
+              description: An award won by or for this item.
+              $ref: "#/components/schemas/schemaAward"
+            schema:comment:
+              title: user notes or reviews
+              description: Comments, typically from users.
+              $ref: "#/components/schemas/schemaComment"
+            schema:funding:
+              title: funding
+              description: A Grant that directly or indirectly provide funding or sponsorship for this item.
+              $ref: "#/components/schemas/schemaFunding"
+            schema:publishingPrinciples:
+              title: publishingPrinciples
+              description: The publishingPrinciples property indicates (typically via URL) a document describing the editorial principles of an Organization (or individual, e.g. a Person writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies.
+              $ref: "#/components/schemas/schemaPublishingPrinciples"
+            schema:translator:
+              title: translator
+              description: Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
+              $ref: "#/components/schemas/schemaTranslator"
+            sd:endpoint:
+              title: endpoint
+              description: The SPARQL endpoint of an sd:Service that implements the SPARQL Protocol service. The object of the sd:endpoint property is an IRI.
+              $ref: "#/components/schemas/sdEndpoint"
+            skos:hiddenLabel:
+              title: hidden label
+              description: Hidden or past name.   
+              $ref: "#/components/schemas/rdfsLiteral"
+            vann:changes:
+              title: Changes
+              description: A reference to a resource that describes changes between this version of a vocabulary and the previous.
+              $ref: "#/components/schemas/vannChanges"
+            vann:example:
+              title: example
+              description: A reference to a resource that provides an example of how this resource can be used.
+              $ref: "#/components/schemas/vannExample"
+            vann:preferredNamespacePrefix:
+              title: Preferred Namespace Prefix
+              description: The preferred namespace prefix to use when using terms from this vocabulary in an XML document
+              $ref: "#/components/schemas/vannPreferredNamespacePrefix"
+            vann:preferredNamespaceUri:
+              title: Preferred Namespace Uri
+              description: The preferred namespace URI to use when using terms from this vocabulary in an XML document
+              $ref: "#/components/schemas/vannPreferredNamespaceUri"
+            void:openSearchDescription:
+              title: free-text search endpoint
+              description: An OpenSearch description document for a free-text search service over a void:Dataset.
+              $ref: "#/components/schemas/foafDocument"
+            void:uriLookupEndpoint:
+              title: URI lookup endpoint
+              description: A protocol endpoint for simple URI lookups for a void:Dataset.
+              $ref: "#/components/schemas/xsdAnyURI"
+            void:uriRegexPattern:
+              title: identifier pattern
+              description: A regular expression that matches the URIs of a void:Dataset's entities.
+              $ref: "#/components/schemas/voidUriRegexPattern"
 
     modSemanticArtefactCatalogRecord:
       title: Semantic Artefact Catalog Record
@@ -1297,6 +2111,27 @@ components:
               items:
                 example: mod:SemanticArtefactCatalogRecord
         - $ref: '#/components/schemas/dcatCatalogRecord'
+        - type: object
+          properties:
+            dcterms:dateSubmitted:
+              title: submission date
+              description: Date of submission of the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            foaf:homepage:
+              title: homepage
+              description: An unambiguous reference to the resource within a given context.
+              $ref: "#/components/schemas/foafDocument"
+            dcterms:created:
+              title: creation date
+              description: Date of creation of the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            pav:curatedBy:
+              title: curator
+              description: A curator who restructure the previously authored content and shape it to be appropriate for the intended representation (e.g. by normalizing the fields for being represented in a spreadsheet).
+              $ref: "#/components/schemas/pavCuratedBy"
+            pav:curatedOn:
+              title: curation date
+              $ref: "#/components/schemas/xsdDate"
 
     modSemanticArtefactDistribution:
       title: Semantic Artefact Distribution
@@ -1313,6 +2148,22 @@ components:
         - $ref: '#/components/schemas/dcatDistribution'
         - type: object
           properties:
+            cc:useGuidelines:
+              title: use guidelines
+              description: A related resource which defines non-binding use guidelines for the work.
+              $ref: "#/components/schemas/rdfsResource"
+            dcterms:created:
+              title: creation date
+              description: Date of creation of the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:dateSubmitted:
+              title: submission date
+              description: Date of submission of the resource.
+              $ref: "#/components/schemas/rdfsLiteral"
+            dcterms:valid:
+              title: validity date
+              description: Date (often a range) of validity of a resource.
+              $ref: "#/components/schemas/rdfsLiteral"
             mod:authorProperty:
               title: object author property
               description: Property used to specify objects's author.
@@ -1373,6 +2224,10 @@ components:
               title: FAIR assessment
               description: A FAIRness assessment result produced by a known or identified FAIRness assessment method or tool. It can be either a simple number or a structured result document explaining the assessment.
               $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:hasFormalityLevel:
+              title: formality level
+              description: The level of formality of an ontology.
+              $ref: "#/components/schemas/xsdString"
             mod:hasRepresentationLanguage:
               title: representation language
               description: A language that is used to create an ontology.
@@ -1428,6 +2283,10 @@ components:
               title: number of labels
               description: Number of defined labels for any resources in an ontology (classes, properties, etc).
               $ref: "#/components/schemas/xsdNonNegativeInteger"
+            mod:numberOfMappings:
+              title: number of mappings
+              description: Number of mappings within a given semantic artefact or semantic artefact catalogue.
+              $ref: "#/components/schemas/xsdNonNegativeInteger"
             mod:numberOfObjectProperties:
               title: number of object properties
               description: The total number of object properties in an ontology.
@@ -1460,7 +2319,21 @@ components:
               title: engineering methodology
               description: A methodolgy following which an ontology is created.
               $ref: "#/components/schemas/modEngineeringMethodology"
-
+            owl:deprecated:
+              title: deprecated
+              description: The annotation property that indicates that a given entity has been deprecated.
+              $ref: "#/components/schemas/rdfsResource"
+            owl:imports:
+              title: imports
+              description: References another OWL ontology containing definitions, whose meaning is considered to be part of the meaning of the importing ontology.
+              $ref: "#/components/schemas/owlOntology"
+            pav:curatedOn:
+              title: curation date
+              $ref: "#/components/schemas/xsdDate"
+            sd:endpoint:
+              title: endpoint
+              description: The SPARQL endpoint of an sd:Service that implements the SPARQL Protocol service. The object of the sd:endpoint property is an IRI.
+              $ref: "#/components/schemas/sdEndpoint"
 
     modSemanticArtefactService:
       title: Semantic Artefact Service
@@ -1489,6 +2362,23 @@ components:
                 example: mod:SemanticArtefactTask
         - $ref: '#/components/schemas/owlClass'
 
+    modSimilar:
+      type: object
+      properties:
+        '@type':
+          title: similar
+          description: sed to assert that two vocabularies are similar in scope and objectives, independently of the fact that they otherwise refer to each other.
+          example: mod:similar
+
+
+    modSpecializes:
+      type: object
+      properties:
+        '@type':
+          title: specializes
+          description: Indicates that the subject vocabulary defines some subclasses or subproperties of the object vocabulary, or local restrictions on those.
+          example: mod:specializes
+
     modTaxonomy:
       title: Taxonomy
       allOf:
@@ -1503,6 +2393,30 @@ components:
       title: Thesaurus
       allOf:
         - $ref: '#/components/schemas/modSemanticArtefact'
+
+    modUsedBy:
+      type: object
+      properties:
+        '@type':
+          title: used by
+          description: Indicates that the subject vocabulary is used by the object vocabulary.
+          example: mod:usedBy
+
+    modUsedInProject:
+      type: object
+      properties:
+        '@type':
+          title: used in project
+          description: An ontology that is used in a project.
+          example: mod:usedInProject
+
+    modReliesOn:
+      type: object
+      properties:
+        '@type':
+          title: relies on or reuses
+          description: A general property for different kind of case when a semantic resource relies or reuses another one.
+          example: mod:reliesOn
 
     odrlPolicy:
       type: object
@@ -1530,6 +2444,18 @@ components:
           description: An owl individual
           example: owl:Individual
 
+    owlOntology:
+      type: object
+      properties:
+        '@type':
+          example: owl:Ontology
+
+    owlThing:
+      type: object
+      properties:
+        '@type':
+          example: owl:Thing
+
     Pagination:
       type: object
       properties:
@@ -1548,6 +2474,22 @@ components:
               title: next page
               description: The URL of the next page of the results
               example: 'https://example.org/ont1?page=5&pagesize=50'
+
+    pavCreatedWith:
+      type: object
+      properties:
+        '@type':
+          title: Created with
+          description: The software/tool used by the creator (pav:createdBy) when making the digital resource, for instance a word processor or an annotation tool. A more independent software agent that creates the resource without direct interaction by a human creator should instead should instead by indicated using pav:createdBy.
+          example: mod:createdWith
+
+    pavCuratedBy:
+      type: object
+      properties:
+        '@type':
+          title: Curated by
+          description: Specifies an agent specialist responsible for shaping the expression in an appropriate format. Often the primary agent responsible for ensuring the quality of the representation. The curator may be different from the author (pav:authoredBy) and creator of the digital resource (pav:createdBy). The curator may in some cases be a software agent, for instance text mining software which adds hyperlinks for recognized genome names. The date of curating can be expressed using pav:curatedOn - note however in the case of multiple curators that there is no relationship in PAV identifying which agent contributed when or what. If capturing such lineage is desired, it should be additionally expressed using PROV relationships like prov:qualifiedAttribution or prov:wasGeneratedBy.
+          example: pav:curatedBy
 
     provActivity:
       type: object
@@ -1595,6 +2537,86 @@ components:
           description: The class resource, everything.
           example: rdfs:Resource
 
+    schemaAssociatedMedia:
+      type: object
+      properties:
+        '@type':
+          title: associatedMedia
+          description: A media object that encodes this CreativeWork. This property is a synonym for encoding.
+          example: schema:associatedMedia
+
+    schemaAward:
+      type: object
+      properties:
+        '@type':
+          title: award
+          description: An award won by or for this item.
+          example: schema:award
+
+    schemaComment:
+      type: object
+      properties:
+        '@type':
+          title: comment
+          description: Comments, typically from users.
+          example: schema:comment
+
+    schemaFunding:
+      type: object
+      properties:
+        '@type':
+          title: funding
+          description: A Grant that directly or indirectly provide funding or sponsorship for this item.
+          example: schema:funding
+
+    schemaIncludedInDataCatalog:
+      type: object
+      properties:
+        '@type':
+          title: includedInDataCatalog
+          description: A data catalog which contains this dataset.
+          example: schema:includedInDataCatalog
+
+    schemaPublishingPrinciples:
+      type: object
+      properties:
+        '@type':
+          title: publishingPrinciples
+          description: The publishingPrinciples property indicates (typically via URL) a document describing the editorial principles of an Organization (or individual, e.g. a Person writing a blog) that relate to their activities as a publisher, e.g. ethics or diversity policies.
+          example: schema:publishingPrinciples
+
+    schemaTranslationOfWork:
+      type: object
+      properties:
+        '@type':
+          title: translationOfWork
+          description: The work that this work has been translated from. E.g. 物种起源 is a translationOf “On the Origin of Species”.
+          example: schema:translationOfWork
+
+    schemaTranslator:
+      type: object
+      properties:
+        '@type':
+          title: translator
+          description: Organization or person who adapts a creative work to different languages, regional differences and technical requirements of a target market, or that translates during some event.
+          example: schema:translator
+
+    schemaWorkTranslation:
+      type: object
+      properties:
+        '@type':
+          title: workTranslation
+          description: A work that is a translation of the content of this work. E.g. 西遊記 has an English workTranslation “Journey to the West”, a German workTranslation “Monkeys Pilgerfahrt” and a Vietnamese translation Tây du ký bình khảo.
+          example: schema:workTranslation
+
+    sdEndpoint:
+      type: object
+      properties:
+        '@type':
+          title: endpoint
+          description: The SPARQL endpoint of an sd:Service that implements the SPARQL Protocol service. The object of the sd:endpoint property is an IRI.
+          example: sd:endpoint
+
     skosCollection:
       type: object
       properties:
@@ -1612,15 +2634,47 @@ components:
           example: skos:Concept
         skos:prefLabel:
           example: cars
-        
+
     skosScheme:
       type: object
       properties:
         '@type':
           title: ConceptScheme
           example: skos:ConceptScheme
-        dct:title:
+        dcterms:title:
           example: cars scheme
+
+    vannChanges:
+      type: object
+      properties:
+        '@type':
+          title: Changes
+          description: A reference to a resource that describes changes between this version of a vocabulary and the previous.
+          example: vann:changes
+
+    vannExample:
+      type: object
+      properties:
+        '@type':
+          title: Example
+          description: A reference to a resource that provides an example of how this resource can be used.
+          example: vann:example
+
+    vannPreferredNamespacePrefix:
+      type: object
+      properties:
+        '@type':
+          title: Preferred Namespace Prefix
+          description: The preferred namespace prefix to use when using terms from this vocabulary in an XML document
+          example: vann:preferredNamespacePrefix
+
+    vannPreferredNamespaceUri:
+      type: object
+      properties:
+        '@type':
+          title: Preferred Namespace Uri
+          description: The preferred namespace URI to use when using terms from this vocabulary in an XML document
+          example: vann:preferredNamespaceUri
 
     vcardKind:
       type: object
@@ -1635,6 +2689,26 @@ components:
           example: Corky Crystal
         vcard:nickname:
           example: Corks
+
+    voidDataset:
+      type: object
+      properties:
+        '@type':
+          title: dataset
+          example: void:dataset
+
+    voidUriRegexPattern:
+      type: object
+      properties:
+        '@type':
+          title: identifier pattern
+          example: void:uriRegexPattern
+
+    xsdDate:
+      type: object
+      properties:
+        '@type':
+          example: xsd:date
 
     xsdDecimal:
       type: object


### PR DESCRIPTION
This addresses issues raised in #2 

The following have been added to the `yaml`

# SemanticArtefact

- cc:useGuidelines
- cc:morePermissions
- dcat:downloadURL
- foaf:primaryTopic
- dcterms:abstract
- dcterms:accrualMethod
- dcterms:accrualPeriodicity
- dcterms:accrualPolicy
- dcterms:alternative
- dcterms:audience
- dcterms:bibliographicCitation
- dcterms:contributor
- dcterms:coverage
- dcterms:hasFormat
- dcterms:hasPart
- dcterms:hasVersion
- dcterms:isFormatOf
- dcterms:isPartOf
- dcterms:rightsHolder
- dcterms:source
- doap:bug-database
- doap:mailing-list
- doap:repository
- foaf:depiction
- foaf:fundedBy
- foaf:homepage
- foaf:logo
- mod:comesFromTheSameDomain
- mod:generalizes
- mod:hasDisjunctionsWith
- mod:hasDisparateModelling
- mod:hasEquivalencesWith
- mod:numberOfAgents
- mod:numberOfUsers
- mod:reliesOn
- mod:similar
- mod:specializes
- mod:toDoList
- mod:usedBy
- owl:backwardCompatibleWith
- owl:deprecated
- owl:incompatibleWith
- owl:priorVersion
- owl:versionInfo
- owl:versionIRI
- pav:curatedBy
- pav:createdWith
- prov:wasGeneratedBy
- prov:wasInvalidatedBy
- rdfs:comment
- schema:associatedMedia
- schema:award
- schema:comment
- schema:funding
- schema:includedInDataCatalog
- schema:translationOfWork
- schema:translator
- schema:workTranslation
- skos:hiddenLabel
- vann:changes
- vann:example
- vann:preferredNamespacePrefix
- vann:preferredNamespaceUri
- void:openSearchDescription
- void:classPartition
- void:exampleResource
- void:rootResource
- void:propertyPartition
- void:uriLookupEndpoint
- void:uriRegexPattern

# SemanticArtefactCatalog

- adms:supportedSchema
- cc:useGuidelines
- cc:morePermissions
- dcat:accessURL
- dcterms:abstract
- dcterms:accrualMethod
- dcterms:accrualPeriodicity
- dcterms:accrualPolicy
- dcterms:alternative
- dcterms:audience
- dcterms:bibliographicCitation
- dcterms:created
- dcterms:contributor
- dcterms:coverage
- dcterms:isPartOf
- dcterms:modified
- dcterms:rightsHolder
- dcterms:source
- doap:bug-database
- doap:mailing-list
- doap:repository
- foaf:depiction
- foaf:fundedBy
- foaf:logo
- mod:analytics
- mod:endorsedBy
- mod:fairScore
- mod:hasFormalityLevel
- mod:group
- mod:hasEvaluation
- mod:knownUsage
- mod:metadataVoc
- mod:metrics
- mod:numberOfAgents
- mod:numberOfArtefacts
- mod:numberOfAxioms
- mod:numberOfClasses
- mod:numberOfDataProperties
- mod:numberOfDeprecated
- mod:numberOfEnsorments
- mod:numberOfIndividuals
- mod:numberOfLabels
- mod:numberOfMappings
- mod:numberOfObjectProperties
- mod:numberOfProperties
- mod:numberOfUsers
- mod:numberOfUsingProjects
- mod:toDoList
- mod:status
- mod:usedInProject
- owl:deprecated
- owl:versionInfo
- pav:curatedOn
- pav:curatedBy
- pav:createdWith
- prov:wasGeneratedBy
- rdfs:comment
- schema:associatedMedia
- schema:award
- schema:comment
- schema:funding
- schema:publishingPrinciples
- schema:translator
- sd:endpoint
- skos:hiddenLabel
- vann:changes
- vann:example
- vann:preferredNamespacePrefix
- vann:preferredNamespaceUri
- void:openSearchDescription
- void:uriLookupEndpoint
- void:uriRegexPattern

# SemanticArtefactCatalogRecord

- dcterms:dateSubmitted
- foaf:homepage
- dcterms:created
- pav:curatedBy
- pav:curatedOn

# SemanticArtefactDistribution

- cc:useGuidelines
- dcterms:created
- dcterms:dateSubmitted
- dcterms:valid
- pav:curatedOn
- mod:numberOfMappings
- owl:deprecated
- owl:imports
- sd:endpoint
