### PR TITLE
Update the way example output is generated

### DIFF
--- a/mod_api/static/mod_api/openapi.yaml
+++ b/mod_api/static/mod_api/openapi.yaml
@@ -243,12 +243,19 @@ components:
                 $ref: "#/components/schemas/Context"
             allOf:
               - $ref: "#/components/schemas/modSemanticArtefactCatalog"
+          examples:
+            record:
+              $ref: "#/components/examples/semanticArtefactCatalog"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            semanticArtefactCatalog:
+              summary: Semantic Artefact Catalog
+              externalValue: "./ttl/catalog.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -256,7 +263,10 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            semanticArtefactCatalog:
+              summary: Semantic Artefact Catalog
+              externalValue: "./xml/catalog.xml"
 
     classes:
       description: "OK"
@@ -1211,6 +1221,7 @@ components:
           qualifiedAttribution: 'prov:qualifiedAttribution'
           qualifiedRelation: 'dcat:qualifiedRelation'
           relation: 'dcterms:relation'
+          Relationship: 'dcat:Relationship'
           reliesOn: 'mod:reliesOn'
           repository: 'doap:repository'
           Resource: 'rdfs:Resource'
@@ -1225,7 +1236,7 @@ components:
           specializes: 'mod:specializes'
           status: 'mod:status'
           string: 'xsd:string'
-          subject: 'dcterms:subject'
+          theme: 'dcat:theme'
           Thing: 'owl:Thing'
           title: 'dcterms:title'
           toDoList: 'mod:toDoList'
@@ -1279,10 +1290,14 @@ components:
         qualifiedAttribution:
           '@id': 'https://example.org/Attribution/AttributionID'
           '@type': Attribution
-        qualifiedRelation: string
+        qualifiedRelation: 
+          '@id': 'https://example.org/Relationship/RelationshipID'
+          '@type': Relationship
         relation: string
         rights: string
-        subject: string
+        theme:
+          '@id': 'https://example.org/Theme/ThemeID'
+          '@type': Resource
         title:
           '@type': Literal
           '@value': Lorem ipsum
@@ -1593,6 +1608,7 @@ components:
           qualifiedAttribution: 'prov:qualifiedAttribution'
           qualifiedRelation: 'dcat:qualifiedRelation'
           relation: 'dcterms:relation'
+          Relationship: 'dcat:Relationship'
           reliesOn: 'mod:reliesOn'
           repository: 'doap:repository'
           Resource: 'rdfs:Resource'
@@ -1607,7 +1623,7 @@ components:
           specializes: 'mod:specializes'
           status: 'mod:status'
           string: 'xsd:string'
-          subject: 'dcterms:subject'
+          theme: 'dcat:theme'
           Thing: 'owl:Thing'
           title: 'dcterms:title'
           toDoList: 'mod:toDoList'
@@ -1671,10 +1687,14 @@ components:
             qualifiedAttribution:
               '@id': 'https://example.org/Attribution/AttributionID'
               '@type': Attribution
-            qualifiedRelation: string
+            qualifiedRelation:
+              '@id': 'https://example.org/Relationship/RelationshipID'
+              '@type': Relationship
             relation: string
             rights: string
-            subject: string
+            theme:
+              '@id': 'https://example.org/Theme/ThemeID'
+              '@type': Resource
             title:
               '@type': Literal
               '@value': Lorem ipsum
@@ -1860,6 +1880,390 @@ components:
           previousPage: 'https://example.org/items?page=2'
           nextPage: 'https://example.org/items?page=4'
           lastPage: 'https://example.org/items?page=42'
+
+    semanticArtefactCatalog:
+      summary: Semantic Artefact Catalog
+      value:
+        '@context':
+          adms: 'http://www.w3.org/ns/adms#'
+          cc: 'http://creativecommons.org/ns#'
+          dcat: 'http://www.w3.org/ns/dcat#'
+          dcterms: 'http://purl.org/dc/terms/'
+          doap: 'http://usefulinc.com/ns/doap#'
+          foaf: 'http://xmlns.com/foaf/0.1/'
+          ical: 'http://www.w3.org/2002/12/cal/ical#'
+          mod: 'https://w3id.org/mod#'
+          odrl: 'http://www.w3.org/ns/odrl/2/'
+          owl: 'http://www.w3.org/2002/07/owl#'
+          pav: 'http://purl.org/pav/'
+          prov: 'http://www.w3.org/ns/prov#'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          schema: 'https://schema.org/'
+          sd: 'http://www.w3.org/ns/sparql-service-description#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          vann: 'https://vocab.org/vann/'
+          vcard: 'http://www.w3.org/2006/vcard/ns#'
+          void: 'http://rdfs.org/ns/void#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          abstract: dcterms:abstract
+          anyURI: xsd:anyURI
+          accessRights: dcterms:accessRights
+          accessURL: dcat:accessURL
+          accrualMethod: dcterms:accrualMethod
+          accrualPeriodicity: dcterms:accrualPeriodicity
+          accrualPolicy: dcterms:accrualPolicy
+          Activity: prov:Activity
+          alternative: dcterms:alternative
+          analytics: mod:analytics
+          Analytics: mod:Analytics
+          Asset: adms:Asset
+          associatedMedia: schema:associatedMedia
+          Attribution: prov:Attribution
+          audience: dcterms:audience
+          award: schema:award
+          bibliographicCitation: dcterms:bibliographicCitation
+          bug-database: doap:bug-database
+          catalog: dcat:catalog
+          Catalog: dcat:Catalog
+          CatalogRecord: dcat:CatalogRecord
+          changes: vann:changes
+          comment: rdfs:comment
+          conformsTo: dcterms:conformsTo
+          contactPoint: dcat:contactPoint
+          contributor: dcterms:contributor
+          coverage: dcterms:coverage
+          created: dcterms:created
+          createdWith: pav:createdWith
+          creator: dcterms:creator
+          curatedBy: pav:curatedBy
+          curatedOn: pav:curatedOn
+          dataset: dcat:dataset
+          Dataset: dcat:Dataset
+          DataService: dcat:DataService
+          date: xsd:date
+          depiction: foaf:depiction
+          deprecated: owl:deprecated
+          description: dcterms:description
+          distribution: dcat:distribution
+          Distribution: dcat:Distribution
+          Document: foaf:Document
+          endorsedBy: mod:endorsedBy
+          endpoint: sd:endpoint
+          example: vann:example
+          fairScore: mod:fairScore
+          fn: vcard:fn
+          fundedBy: foaf:fundedBy
+          funding: schema:funding
+          group: mod:group
+          Group: mod:Group
+          hasPart: dcterms:hasPart
+          hasPolicy: odrl:hasPolicy
+          hiddenLabel: skos:hiddenLabel
+          homepage: foaf:homepage
+          identifier: dcterms:identifier
+          Image: foaf:Image
+          isPartOf: dcterms:isPartOf
+          isReferencedBy: dcterms:isReferencedBy
+          issued: dcterms:issued
+          keyword: dcat:keyword
+          Kind: vcard:Kind
+          knownUsage: mod:knownUsage
+          landingPage: dcat:landingPage
+          language: dcterms:language
+          license: dcterms:license
+          Literal: rdfs:Literal
+          logo: foaf:logo
+          mailing-list: doap:mailing-list
+          metadataVoc: mod:metadataVoc
+          metrics: mod:metrics
+          modified: dcterms:modified
+          morePermissions: cc:morePermissions
+          nickname: vcard:nickname
+          nonNegativeInteger: xsd:nonNegativeInteger
+          numberOfAgents: mod:numberOfAgents
+          numberOfArtefacts: mod:numberOfArtefacts
+          numberOfAxioms: mod:numberOfAxioms
+          numberOfClasses: mod:numberOfClasses
+          numberOfDataProperties: mod:numberOfDataProperties
+          numberOfDeprecated: mod:numberOfDeprecated
+          numberOfEndorsements: mod:numberOfEndorsements
+          numberOfIndividuals: mod:numberOfIndividuals
+          numberOfLabels: mod:numberOfLabels
+          numberOfMappings: mod:numberOfMappings
+          numberOfObjectProperties: mod:numberOfObjectProperties
+          numberOfProperties: mod:numberOfProperties
+          numberOfUsers: mod:numberOfUsers
+          numberOfUsingProjects: mod:numberOfUsingProjects
+          openSearchDescription: void:openSearchDescription
+          Policy: odrl:Policy
+          preferredNamespacePrefix: vann:preferredNamespacePrefix
+          preferredNamespaceUri: vann:preferredNamespaceUri
+          Project: foaf:Project
+          publisher: dcterms:publisher
+          publishingPrinciples: schema:publishingPrinciples
+          qualifiedAttribution: prov:qualifiedAttribution
+          qualifiedRelation: dcat:qualifiedRelation
+          record: dcat:record
+          relation: dcterms:relation
+          Relationship: dcat:Relationship
+          repository: doap:repository
+          Resource: rdfs:Resource
+          dcatResource: dcat:Resource
+          rights: dcterms:rights
+          rightsHolder: dcterms:rightsHolder
+          schemaComment: schema:comment
+          SemanticArtefactCatalog: mod:SemanticArtefactCatalog
+          service: dcat:service
+          source: dcterms:source
+          spatial: dcterms:spatial
+          spatialResolutionInMeters: dcat:spatialResolutionInMeters
+          status: mod:status
+          string: xsd:string
+          supportedSchema: adms:supportedSchema
+          temporal: dcterms:temporal
+          temporalResolution: dcat:temporalResolution
+          theme: dcat:theme
+          themeTaxonomy: dcat:themeTaxonomy
+          Thing: owl:Thing
+          title: dcterms:title
+          toDoList: mod:toDoList
+          translator: schema:translator
+          type: dcterms:type
+          uriLookupEndpoint: void:uriLookupEndpoint
+          uriRegexPattern: void:uriRegexPattern
+          usedInProject: mod:usedInProject
+          useGuidelines: cc:useGuidelines
+          versionInfo: owl:versionInfo
+          Vtodo: ical:Vtodo
+          wasGeneratedBy: prov:wasGeneratedBy
+
+        '@id': >-
+          https://example.org/SemanticArtefactCatalog/SemanticArtefactCatalogID
+        '@type': SemanticArtefactCatalog
+        accessRights: string
+        conformsTo: string
+        contactPoint:
+          '@id': 'https://example.org/vcardKind/vcardKindID'
+          '@type': Kind
+          fn: Corky Crystal
+          nickname: Corks
+        creator: string
+        description:
+          '@type': Literal
+          '@value': Lorem ipsum
+        hasPolicy:
+          '@id': 'https://example.org/Policy/PolicyID'
+          '@type': Policy
+        identifier:
+          '@type': Literal
+          '@value': Lorem ipsum
+        isReferencedBy: string
+        issued: string
+        keyword: string
+        landingPage:
+          '@id': 'https://example.org/Document/DocumentID'
+          '@type': Document
+        language: string
+        license: string
+        publisher: string
+        qualifiedAttribution:
+          '@id': 'https://example.org/Attribution/AttributionID'
+          '@type': Attribution
+        qualifiedRelation:
+          '@id': 'https://example.org/Relationship/RelationshipID'
+          '@type': Relationship
+        relation: string
+        rights: string
+        theme:
+          '@id': 'https://example.org/Theme/ThemeID'
+          '@type': Resource
+        title:
+          '@type': Literal
+          '@value': Lorem ipsum
+        type: string
+        distribution:
+          '@id': 'https://example.org/Distribution/DistributionID'
+          '@type': Distribution
+        spatial: string
+        spatialResolutionInMeters: string
+        temporal: string
+        temporalResolution: string
+        catalog:
+          '@id': 'https://example.org/Catalog/CatalogID'
+          '@type': Catalog
+        dataset:
+          '@id': 'https://example.org/Dataset/DatasetID'
+          '@type': Dataset
+        hasPart:
+          '@id': 'https://example.org/Resource/ResourceID'
+          '@type': dcatResource
+        homepage:
+          '@id': 'https://example.org/Document/DocumentID'
+          '@type': Document
+        record:
+          '@id': 'https://example.org/CatalogRecord/CatalogRecordID'
+          '@type': CatalogRecord
+        service:
+          '@id': 'https://example.org/DataService/DataServiceID'
+          '@type': DataService
+        themeTaxonomy:
+          '@id': 'https://example.org/Resource/ThemeTaxonomyResourceID'
+          '@type': Resource
+        supportedSchema:
+          '@id': https://example.org/asset/assetId
+          '@type': Asset
+        useGuidelines:
+          '@id': 'https://example.org/Resource/UseGuidelinesResourceID'
+          '@type': Resource
+        morePermissions:
+          '@id': 'https://example.org/Resource/MorePermissionsResourceID'
+          '@type': Resource
+        accessURL:
+          '@id': 'https://example.org/Resource/AccessURLResourceID'
+          '@type': Resource
+        abstract: string
+        accrualMethod: string
+        accrualPeriodicity: string
+        accrualPolicy: string
+        alternative:
+          '@type': Literal
+          '@value': Lorem ipsum
+        audience: string
+        bibliographicCitation:
+          '@type': Literal
+          '@value': Lorem ipsum
+        created:
+          '@type': Literal
+          '@value': Lorem ipsum
+        contributor: string
+        coverage: string
+        isPartOf: string
+        modified:
+          '@type': Literal
+          '@value': Lorem ipsum
+        rightsHolder: string
+        source: string
+        bug-database: string
+        mailing-list: string
+        repository:
+          '@id': 'https://example.org/repository/repositoryID'
+          '@type': repository
+        depiction:
+          '@id': 'https://example.org/Image/ImageID'
+          '@type': Image
+        fundedBy:
+          '@id': 'https://example.org/Thing/ThingID'
+          '@type': Thing
+        logo:
+          '@id': 'https://example.org/Thing/ThingID'
+          '@type': Thing
+        analytics:
+          '@id': 'https://example.org/Analytics/AnalyticsID'
+          '@type': Analytics
+        endorsedBy: string
+        fairScore:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        group:
+          '@id': 'https://example.org/Group/GroupID'
+          '@type': Group
+        knownUsage:
+          '@type': string
+          '@value': Lorem ipsum
+        metadataVoc:
+          '@type': anyURI
+          '@value': https://example.org/metadataVoc
+        metrics:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfAgents:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfArtefacts:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfAxioms:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfClasses:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfDataProperties:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfDeprecated:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfEndorsements:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfIndividuals:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfLabels:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfMappings:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfObjectProperties:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfProperties:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfUsers:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfUsingProjects:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        toDoList:
+          '@id': 'https://example.org/Vtodo/VtodoID'
+          '@type': Vtodo
+        status:
+          '@type': string
+          '@value': Lorem ipsum
+        usedInProject:
+          '@id': 'https://example.org/Project/ProjectID'
+          '@type': Project
+        deprecated:
+          '@id': 'https://example.org/Resource/DeprecatedResourceID'
+          '@type': Resource
+        versionInfo:
+          '@type': string
+          '@value': Lorem ipsum
+        curatedOn:
+          '@type': date
+        curatedBy: string
+        createdWith: string
+        wasGeneratedBy:
+          '@id': 'https://example.org/Activity/ActivityID'
+          '@type': Activity
+        comment:
+          '@type': Literal
+          '@value': Lorem ipsum
+        associatedMedia: string
+        award: string
+        schemaComment: string
+        funding: string
+        publishingPrinciples: string
+        translator: string
+        endpoint: string
+        hiddenLabel:
+          '@type': Literal
+          '@value': Lorem ipsum
+        changes: string
+        example: string
+        preferredNamespacePrefix: string
+        preferredNamespaceUri: string
+        openSearchDescription:
+          '@id': 'https://example.org/Document/DocumentID'
+          '@type': Document
+        uriLookupEndpoint:
+          '@type': anyURI
+          '@value': https://example.org/uriLookupEndpoint
+        uriRegexPattern: string
 
     semanticArtefactCatalogRecord:
       summary: Semantic Artefact Catalog Record
@@ -2226,7 +2630,9 @@ components:
         numberOfAxioms:
           '@type': nonNegativeInteger
           '@value': 5436
-        numberOfClasses: 0
+        numberOfClasses:
+          '@type': nonNegativeInteger
+          '@value': 5436
         numberOfDataProperties:
           '@type': nonNegativeInteger
           '@value': 5436
@@ -2515,7 +2921,9 @@ components:
             numberOfAxioms:
               '@type': nonNegativeInteger
               '@value': 5436
-            numberOfClasses: 0
+            numberOfClasses:
+              '@type': nonNegativeInteger
+              '@value': 5436
             numberOfDataProperties:
               '@type': nonNegativeInteger
               '@value': 5436
@@ -2921,15 +3329,36 @@ components:
             dcat:catalog:
               title: catalog
               description: A catalog whose contents are of interest in the context of this catalog.
-              $ref: "#/components/schemas/dcatCatalog"
+              type: array
+              items:
+                type: object
+                properties:
+                  '@id':
+                    example: https://example.org/Catalog/CatalogID
+                  '@type':
+                    example: dcat:Catalog
             dcat:dataset:
               title: dataset
               description: A collection of data that is listed in the catalog.
-              $ref: "#/components/schemas/dcatDataset"
+              type: array
+              items:
+                type: object
+                properties:
+                  '@id':
+                    example: https://example.org/Dataset/DatasetID
+                  '@type':
+                    example: dcat:Dataset
             dcterms:hasPart:
               title: has part
               description: An item that is listed in the catalog.
-              $ref: "#/components/schemas/dcatResource"
+              type: array
+              items:
+                type: object
+                properties:
+                  '@id':
+                    example: https://example.org/Resource/ResourceID
+                  '@type':
+                    example: dcat:Resource
             foaf:homepage:
               title: homepage
               description: A homepage of the catalog (a public Web document usually available in HTML).
@@ -2942,21 +3371,32 @@ components:
             dcat:record:
               title: catalog record
               description: A record describing the registration of a single dataset or data service that is part of the catalog.
-              type: array
-              items:
-                $ref: "#/components/schemas/dcatCatalogRecord"
-            dcat:resource:
-              title: resource
-              description: A resource that is listed in the catalog.
-              $ref: "#/components/schemas/dcatResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/CatalogRecord/CatalogRecordID
+                '@type':
+                  example: dcat:CatalogRecord
             dcat:service:
               title: service
               description: A site or end-point that is listed in the catalog.
-              $ref: "#/components/schemas/dcatDataService"
+              type: array
+              items:
+                type: object
+                properties:
+                  '@id':
+                    example: https://example.org/DataService/DataServiceID
+                  '@type':
+                    example: dcat:DataService
             dcat:themeTaxonomy:
               title: themes
               description: A knowledge organization system (KOS) used to classify catalog's datasets and services.
-              $ref: "#/components/schemas/rdfsResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/Resource/ThemeTaxonomyResourceID
+                '@type':
+                  example: rdfs:Resource
 
     # see https://www.w3.org/TR/vocab-dcat-2/#Class:Catalog_Record
     dcatCatalogRecord:
@@ -3031,7 +3471,14 @@ components:
             dcat:servesDataset:
               tile: serves dataset
               description: A collection of data that this data service can distribute.
-              $ref: "#/components/schemas/dcatDataset"
+              type: array
+              items:
+                type: object
+                properties:
+                  '@id':
+                    example: https://example.org/Dataset/DatasetID
+                  '@type':
+                    example: dcat:Dataset
 
     # see https://www.w3.org/TR/vocab-dcat-2/#Class:Dataset
     dcatDataset:
@@ -3047,7 +3494,14 @@ components:
             dcat:distribution:
               title: dataset distribution
               description: An available distribution of the dataset.
-              $ref: "#/components/schemas/dcatDistribution"
+              type: array
+              items:
+                type: object
+                properties:
+                  '@id':
+                    example: https://example.org/Distribution/DistributionID
+                  '@type':
+                    example: dcat:Distribution
             dcterms:spatial:
               title: spatial/geographical coverage
               description: The geographical area covered by the dataset.
@@ -3215,7 +3669,12 @@ components:
         dcterms:description:
           title: description
           description: A free-text account of the item.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
         odrl:hasPolicy:
           title: has policy
           description: An ODRL conformant policy expressing the rights associated with the resource.
@@ -3228,7 +3687,12 @@ components:
         dcterms:identifier:
           title: identifier
           description: A unique identifier of the item.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
         dcterms:isReferencedBy:
           title: is referenced by
           description: A related resource, such as a publication, that references, cites, or otherwise points to the cataloged resource.
@@ -3256,7 +3720,12 @@ components:
         dcterms:modified:
           title: update/modification date
           description: Most recent date on which the item was changed, updated or modified.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
         dcterms:publisher:
           title: publisher
           description: The entity responsible for making the item available.
@@ -3272,7 +3741,12 @@ components:
         dcat:qualifiedRelation:
           title: qualified relation
           description: Link to a description of a relationship with another resource.
-          $ref: "#/components/schemas/dcatResource"
+          type: object
+          properties:
+            '@id':
+              example: https://example.org/Relationship/RelationshipID
+            '@type':
+              example: dcat:Relationship
         dcterms:relation:
           title: resource relation
           description: A resource with an unspecified relationship to the cataloged item.
@@ -3287,13 +3761,18 @@ components:
             type: object
             properties:
               '@id':
-                example: https://example.org/Resource/ThemeResourceID
+                example: https://example.org/Theme/ThemeID
               '@type':
                 example: rdfs:Resource
         dcterms:title:
           title: title
           description: A name given to the item.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
         dcterms:type:
           title: type/genre
           description: The nature or genre of the resource.
@@ -3747,15 +4226,30 @@ components:
             cc:useGuidelines:
               title: use guidelines
               description: A related resource which defines non-binding use guidelines for the work.
-              $ref: "#/components/schemas/rdfsResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/Resource/UseGuidelinesResourceID
+                '@type':
+                  example: rdfs:Resource
             cc:morePermissions:
               title: more permissions
               description: A related resource which describes additional permissions or alternative licenses for a Work which may be available.
-              $ref: "#/components/schemas/rdfsResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/Resource/MorePermissionsResourceID
+                '@type':
+                  example: rdfs:Resource
             dcat:accessURL:
               title: access URL
               description: A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.
-              $ref: "#/components/schemas/rdfsResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/Resource/AccessURLResourceID
+                '@type':
+                  example: rdfs:Resource
             dcterms:abstract:
               title: abstract
               description: A summary of the resource.
@@ -3771,18 +4265,33 @@ components:
             dcterms:alternative:
               title: alternative title
               description: An alternative name for the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:audience:
               title: target audience
               description: A class of agents for whom the resource is intended or useful.
             dcterms:bibliographicCitation:
               title: bibliographic reference
               description: A bibliographic reference for the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:created:
               title: creation date
               description: Date of creation of the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:contributor:
               title: contributor
               description: An entity responsible for making contributions to the resource.
@@ -3795,7 +4304,12 @@ components:
             dcterms:modified:
               title: modification date
               description: Date on which the resource was changed.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:rightsHolder:
               title: rights holder
               description: The person who can be contacted to enquire about an ontology.
@@ -3859,7 +4373,12 @@ components:
             mod:fairScore:
               title: FAIR assessment
               description: A FAIRness assessment result produced by a known or identified FAIRness assessment method or tool. It can be either a simple number or a structured result document explaining the assessment.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:group:
               title: group
               description: A group of ontologies that the ontology is usually considered into.
@@ -3872,70 +4391,155 @@ components:
             mod:knownUsage:
               title: known usage
               description: The applications where the ontology is being used.
-              $ref: "#/components/schemas/xsdString"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:string
+                '@value':
+                  example: Lorem ipsum
             mod:metadataVoc:
               title: metadata vocabulary used
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/metadataVoc
             mod:metrics:
               title: metrics
               description: A generic property to store any metrics (number) related to the ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfAgents:
               title: number of agents
               description: Total number of agents in a semantic artefact catalogue or number of agents related a given semantic artefact.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfArtefacts:
               title: number of semantic artefacts
               description: Total number of semantic artefacts within a catalog.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfAxioms:
               title: number of axioms or triples
               description: The total number of axioms in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfClasses:
               title: number of classes
               description: The total number of classes in an ontology.
-              type: integer
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfDataProperties:
               title: number of data properties
               description: The total number of data properties in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfDeprecated:
               title: number of deprecated objects
               description: The total number of  in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfEndorsements:
               title: number of endorsmements
               description: Number of endorsing organizations (maybe represented with mod:endorsedBy).
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfIndividuals:
               title: number of individuals
               description: The total number of individuals in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfLabels:
               title: number of labels
               description: Number of defined labels for any resources in an ontology (classes, properties, etc).
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfMappings:
               title: number of mappings
               description: Number of mappings within a given semantic artefact or semantic artefact catalogue.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfObjectProperties:
               title: number of object properties
               description: The total number of object properties in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfProperties:
               title: number of properties
               description: The total number of properties in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfUsers:
               title: number of users
               description: Total number of users in a semantic artefact catalogue or number of users watching/following/using a given semantic artefact.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfUsingProjects:
               title: number of using projects
               description: Number of projects (maybe represented with mod:usedInProject) using an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:toDoList:
               title: to-do list
               description: Describes future tasks planned by a resource curator. This property is primarily intended to be used for vocabularies or datasets, but the domain is left open, it can be used for any resource. Use iCalendar Vtodo class and its properties to further describe the task calendar, priorities etc.
@@ -3947,7 +4551,12 @@ components:
                   example: ical:Vtodo
             mod:status:
               title: status
-              $ref: "#/components/schemas/xsdString"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:string
+                '@value':
+                  example: Lorem ipsum
             mod:usedInProject:
               title: used in project
               description: An ontology that is used in a project.
@@ -3960,11 +4569,21 @@ components:
             owl:deprecated:
               title: deprecated
               description: The annotation property that indicates that a given entity has been deprecated.
-              $ref: "#/components/schemas/rdfsResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/Resource/DeprecatedResourceID
+                '@type':
+                  example: rdfs:Resource
             owl:versionInfo:
               title: version information
               description: The version of the released ontology.   
-              $ref: "#/components/schemas/xsdString"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:string
+                '@value':
+                  example: Lorem ipsum
             pav:curatedOn:
               title: curation date
               type: object
@@ -3989,7 +4608,12 @@ components:
             rdfs:comment:
               title: notes or comments
               description: A description of the subject resource.      
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             schema:associatedMedia:
               title:
               description: A media object that encodes this CreativeWork. This property is a synonym for encoding.      
@@ -4014,7 +4638,12 @@ components:
             skos:hiddenLabel:
               title: hidden label
               description: Hidden or past name.   
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             vann:changes:
               title: Changes
               description: A reference to a resource that describes changes between this version of a vocabulary and the previous.
@@ -4039,7 +4668,12 @@ components:
             void:uriLookupEndpoint:
               title: URI lookup endpoint
               description: A protocol endpoint for simple URI lookups for a void:Dataset.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/uriLookupEndpoint
             void:uriRegexPattern:
               title: identifier pattern
               description: A regular expression that matches the URIs of a void:Dataset's entities.
@@ -4374,7 +5008,12 @@ components:
             mod:numberOfClasses:
               title: number of classes
               description: The total number of classes in an ontology.
-              type: integer
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfDataProperties:
               title: number of data properties
               description: The total number of data properties in an ontology.

--- a/mod_api/static/mod_api/openapi.yaml
+++ b/mod_api/static/mod_api/openapi.yaml
@@ -411,12 +411,19 @@ components:
                 $ref: "#/components/schemas/Context"
             allOf:
               - $ref: "#/components/schemas/modSemanticArtefactDistribution"
+          examples:
+            semanticArtefactDistribution:
+              $ref: "#/components/examples/semanticArtefactDistribution"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            semanticArtefactDistribution:
+              summary: Semantic Artefact Distribution
+              externalValue: "./ttl/distribution.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -424,7 +431,10 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            semanticArtefactDistribution:
+              summary: Semantic Artefact Distribution
+              externalValue: "./xml/distribution.xml"
 
     distributions:
       description: "OK"
@@ -450,6 +460,9 @@ components:
                   $ref: "#/components/schemas/modSemanticArtefactDistribution"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            semanticArtefactDistributions:
+              $ref: "#/components/examples/semanticArtefactDistributions"
         text/html:
           schema:
             type: array
@@ -457,9 +470,11 @@ components:
               $ref: "#/components/schemas/html"
         text/turtle:
           schema:
-            type: array
-            items:
-              type: string
+            type: string
+          examples:
+            semanticArtefactDistributions:
+              summary: Semantic Artefact Distributions
+              externalValue: "./ttl/distributions.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -467,7 +482,10 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            semanticArtefactDistributions:
+              summary: Semantic Artefact Distributions
+              externalValue: "./xml/distributions.xml"
 
     individuals:
       description: "OK"
@@ -2104,6 +2122,571 @@ components:
           nextPage: 'https://example.org/items?page=4'
           lastPage: 'https://example.org/items?page=42'
 
+    semanticArtefactDistribution:
+      summary: Semantic Artefact Distribution
+      value:
+        '@context':
+          cc: 'http://creativecommons.org/ns#'
+          dcat: 'http://www.w3.org/ns/dcat#'
+          dcterms: 'http://purl.org/dc/terms/'
+          mod: 'https://w3id.org/mod#'
+          odrl: 'http://www.w3.org/ns/odrl/2/'
+          owl: 'http://www.w3.org/2002/07/owl#'
+          pav: 'http://purl.org/pav/'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          sd: 'http://www.w3.org/ns/sparql-service-description#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          accessRights: 'dcterms:accessRights'
+          accessService: 'dcat:accessService'
+          accessURL: 'dcat:accessURL'
+          anyURI: 'xsd:anyURI'
+          authorProperty: 'mod:authorProperty'
+          averageChildCount: 'mod:averageChildCount'
+          browsingUI: 'mod:browsingUI'
+          byteSize: 'dcat:byteSize'
+          classesWithMoreThan25Children: 'mod:classesWithMoreThan25Children'
+          classesWithNoAuthorMetadata: 'mod:classesWithNoAuthorMetadata'
+          classesWithNoDateMetadata: 'mod:classesWithNoDateMetadata'
+          classesWithNoDefinition: 'mod:classesWithNoDefinition'
+          classesWithNoFormalDefinition: 'mod:classesWithNoFormalDefinition'
+          classesWithNoLabel: 'mod:classesWithNoLabel'
+          classesWithOneChild: 'mod:classesWithOneChild'
+          compressFormat: 'dcat:compressFormat'
+          conformsTo: 'dcterms:conformsTo'
+          conformsToKnowledgeRepresentationParadigm: 'mod:conformsToKnowledgeRepresentationParadigm'
+          created: 'dcterms:created'
+          createdProperty: 'mod:createdProperty'
+          curatedOn: 'pav:curatedOn'
+          DataService: 'dcat:DataService'
+          date: 'xsd:date'
+          dateSubmitted: 'dcterms:dateSubmitted'
+          decimal: 'xsd:decimal'
+          definitionProperty: 'mod:definitionProperty'
+          deprecated: 'owl:deprecated'
+          description: 'dcterms:description'
+          downloadURL: 'dcat:downloadURL'
+          endpoint: 'sd:endpoint'
+          EngineeringMethodology: 'mod:EngineeringMethodology'
+          fairAssessment: 'mod:FairAssessment'
+          fairScore: 'mod:fairScore'
+          format: 'dcterms:format'
+          hasFormalityLevel: 'mod:hasFormalityLevel'
+          hasPolicy: 'odrl:hasPolicy'
+          hasRepresentationLanguage: 'mod:hasRepresentationLanguage'
+          hasSyntax: 'mod:hasSyntax'
+          hierarchyProperty: 'mod:hierarchyProperty'
+          imports: 'owl:imports'
+          issued: 'dcterms:issued'
+          KnowledgeRepresentationParadigm: 'mod:KnowledgeRepresentationParadigm'
+          license: 'dcterms:license'
+          Literal: 'rdfs:Literal'
+          maxChildCount: 'mod:maxChildCount'
+          maxDepth: 'mod:maxDepth'
+          mediaType: 'dcat:mediaType'
+          metadataVoc: 'mod:metadataVoc'
+          metrics: 'mod:metrics'
+          modified: 'dcterms:modified'
+          modifiedProperty: 'mod:modifiedProperty'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          numberOfAxioms: 'mod:numberOfAxioms'
+          numberOfClasses: 'mod:numberOfClasses'
+          numberOfDataProperties: 'mod:numberOfDataProperties'
+          numberOfDeprecated: 'mod:numberOfDeprecated'
+          numberOfIndividuals: 'mod:numberOfIndividuals'
+          numberOfLabels: 'mod:numberOfLabels'
+          numberOfMappings: 'mod:numberOfMappings'
+          numberOfObjectProperties: 'mod:numberOfObjectProperties'
+          numberOfProperties: 'mod:numberOfProperties'
+          obsoleteParent: 'mod:obsoleteParent'
+          obsoleteProperty: 'mod:obsoleteProperty'
+          Ontology: 'owl:Ontology'
+          packageFormat: 'dcat:packageFormat'
+          Policy: 'odrl:Policy'
+          prefLabelProperty: 'mod:prefLabelProperty'
+          Resource: 'rdfs:Resource'
+          rights: 'dcterms:rights'
+          sampleQueries: 'mod:sampleQueries'
+          SemanticArtefactDistribution: 'mod:SemanticArtefactDistribution'
+          spatialResolutionInMeters: 'dcat:spatialResolutionInMeters'
+          string: 'xsd:string'
+          synonymProperty: 'mod:synonymProperty'
+          temporalResolution: 'dcat:temporalResolution'
+          title: 'dcterms:title'
+          usedEngineeringMethodology: 'mod:usedEngineeringMethodology'
+          useGuidelines: 'cc:useGuidelines'
+          valid: 'dcterms:valid'
+
+        '@id': >-
+          https://example.org/SemanticArtefactDistribution/SemanticArtefactDistributionID
+        '@type': SemanticArtefactDistribution
+        accessService:
+            '@id': 'https://example.org/DataService/DataServiceID'
+            '@type': DataService
+        accessRights: string
+        accessURL:
+          '@id': 'https://example.org/Resource/AccessURLResourceID'
+          '@type': Resource
+        byteSize: string
+        compressFormat: string
+        conformsTo: string
+        description:
+          '@type': Literal
+          '@value': Lorem ipsum
+        downloadURL:
+          '@id': 'https://example.org/Resource/DownloadURLResourceID'
+          '@type': rdfs:Resource
+        format: string
+        hasPolicy:
+          '@id': 'https://example.org/Policy/PolicyID'
+          '@type': Policy
+        issued:
+          '@type': Literal
+          '@value': Lorem ipsum
+        license: string
+        mediaType: string
+        modified:
+          '@type': Literal
+          '@value': Lorem ipsum
+        packageFormat: string
+        rights: string
+        spatialResolutionInMeters: string
+        temporalResolution: string
+        title:
+          '@type': Literal
+          '@value': Lorem ipsum
+        useGuidelines:
+          '@id': 'https://example.org/Resource/UseGuidelinesResourceID'
+          '@type': Resource
+        created:
+          '@type': Literal
+          '@value': Lorem ipsum
+        dateSubmitted:
+          '@type': Literal
+          '@value': Lorem ipsum
+        dcterms:valid:
+          '@type': Literal
+          '@value': Lorem ipsum
+        authorProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/authorProperty'
+        averageChildCount:
+          '@type': decimal
+          '@value': 4
+        browsingUI:
+          '@type': anyURI
+          '@value': 'https://example.org/browsingUI'
+        classesWithMoreThan25Children:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        classesWithNoAuthorMetadata:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        classesWithNoDateMetadata:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        classesWithNoDefinition:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        classesWithNoFormalDefinition:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        classesWithNoLabel:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        classesWithOneChild:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        conformsToKnowledgeRepresentationParadigm:
+          '@id': 'https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID'
+          '@type': KnowledgeRepresentationParadigm
+        createdProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/createdProperty'
+        definitionProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/definitionProperty'
+        fairAssessment:
+          '@id': 'https://example.org/FairAssessment/FairAssessmentID'
+          '@type': FairAssessment
+        fairScore:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        hasFormalityLevel:
+          '@type': string
+          '@value': Lorem ipsum
+        hasRepresentationLanguage:
+          '@type': string
+          '@value': Lorem ipsum
+        hasSyntax:
+          '@type': anyURI
+          '@value': 'https://example.org/hasSyntax'
+        hierarchyProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/hierarchyProperty'
+        maxChildCount:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        maxDepth:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        metadataVoc:
+          '@type': anyURI
+          '@value': 'https://example.org/metadataVoc'
+        metrics:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        modifiedProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/modifiedProperty'
+        numberOfAxioms:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfClasses: 0
+        numberOfDataProperties:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfDeprecated:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfIndividuals:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfLabels:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfMappings:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfObjectProperties:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfProperties:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        obsoleteParent:
+          '@type': anyURI
+          '@value': 'https://example.org/obsoleteParent'
+        obsoleteProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/obsoleteProperty'
+        prefLabelProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/prefLabelProperty'
+        sampleQueries:
+          '@type': anyURI
+          '@value': 'https://example.org/sampleQueries'
+        synonymProperty:
+          '@type': anyURI
+          '@value': 'https://example.org/synonymProperty'
+        usedEngineeringMethodology:
+          '@id': 'https://example.org/EngineeringMethodology/EngineeringMethodologyID'
+          '@type': EngineeringMethodology
+        deprecated:
+          '@id': 'https://example.org/Resource/DeprecatedResourceID'
+          '@type': Resource
+        imports:
+          '@id': 'https://example.org/Ontology/OntologyID'
+          '@type': Ontology
+        curatedOn:
+          '@type': date
+        endpoint: string
+
+    semanticArtefactDistributions:
+      summary: Semantic Artefact Distributions
+      value:
+        '@context':
+          cc: 'http://creativecommons.org/ns#'
+          dcat: 'http://www.w3.org/ns/dcat#'
+          dcterms: 'http://purl.org/dc/terms/'
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          mod: 'https://w3id.org/mod#'
+          odrl: 'http://www.w3.org/ns/odrl/2/'
+          owl: 'http://www.w3.org/2002/07/owl#'
+          pav: 'http://purl.org/pav/'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          sd: 'http://www.w3.org/ns/sparql-service-description#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          accessRights: 'dcterms:accessRights'
+          accessService: 'dcat:accessService'
+          accessURL: 'dcat:accessURL'
+          anyURI: 'xsd:anyURI'
+          authorProperty: 'mod:authorProperty'
+          averageChildCount: 'mod:averageChildCount'
+          browsingUI: 'mod:browsingUI'
+          byteSize: 'dcat:byteSize'
+          classesWithMoreThan25Children: 'mod:classesWithMoreThan25Children'
+          classesWithNoAuthorMetadata: 'mod:classesWithNoAuthorMetadata'
+          classesWithNoDateMetadata: 'mod:classesWithNoDateMetadata'
+          classesWithNoDefinition: 'mod:classesWithNoDefinition'
+          classesWithNoFormalDefinition: 'mod:classesWithNoFormalDefinition'
+          classesWithNoLabel: 'mod:classesWithNoLabel'
+          classesWithOneChild: 'mod:classesWithOneChild'
+          Collection: 'hydra:Collection'
+          compressFormat: 'dcat:compressFormat'
+          conformsTo: 'dcterms:conformsTo'
+          conformsToKnowledgeRepresentationParadigm: 'mod:conformsToKnowledgeRepresentationParadigm'
+          created: 'dcterms:created'
+          createdProperty: 'mod:createdProperty'
+          curatedOn: 'pav:curatedOn'
+          DataService: 'dcat:DataService'
+          date: 'xsd:date'
+          dateSubmitted: 'dcterms:dateSubmitted'
+          decimal: 'xsd:decimal'
+          definitionProperty: 'mod:definitionProperty'
+          deprecated: 'owl:deprecated'
+          description: 'dcterms:description'
+          downloadURL: 'dcat:downloadURL'
+          endpoint: 'sd:endpoint'
+          EngineeringMethodology: 'mod:EngineeringMethodology'
+          fairAssessment: 'mod:FairAssessment'
+          fairScore: 'mod:fairScore'
+          firstPage: 'hydra:first'
+          format: 'dcterms:format'
+          hasFormalityLevel: 'mod:hasFormalityLevel'
+          hasPolicy: 'odrl:hasPolicy'
+          hasRepresentationLanguage: 'mod:hasRepresentationLanguage'
+          hasSyntax: 'mod:hasSyntax'
+          hierarchyProperty: 'mod:hierarchyProperty'
+          imports: 'owl:imports'
+          itemsPerPage: 'hydra:itemsPerPage'
+          issued: 'dcterms:issued'
+          KnowledgeRepresentationParadigm: 'mod:KnowledgeRepresentationParadigm'
+          lastPage: 'hydra:last'
+          license: 'dcterms:license'
+          Literal: 'rdfs:Literal'
+          maxChildCount: 'mod:maxChildCount'
+          maxDepth: 'mod:maxDepth'
+          mediaType: 'dcat:mediaType'
+          member: 'hydra:member'
+          metadataVoc: 'mod:metadataVoc'
+          metrics: 'mod:metrics'
+          modified: 'dcterms:modified'
+          modifiedProperty: 'mod:modifiedProperty'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          numberOfAxioms: 'mod:numberOfAxioms'
+          numberOfClasses: 'mod:numberOfClasses'
+          numberOfDataProperties: 'mod:numberOfDataProperties'
+          numberOfDeprecated: 'mod:numberOfDeprecated'
+          numberOfIndividuals: 'mod:numberOfIndividuals'
+          numberOfLabels: 'mod:numberOfLabels'
+          numberOfMappings: 'mod:numberOfMappings'
+          numberOfObjectProperties: 'mod:numberOfObjectProperties'
+          numberOfProperties: 'mod:numberOfProperties'
+          obsoleteParent: 'mod:obsoleteParent'
+          obsoleteProperty: 'mod:obsoleteProperty'
+          Ontology: 'owl:Ontology'
+          packageFormat: 'dcat:packageFormat'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          Policy: 'odrl:Policy'
+          prefLabelProperty: 'mod:prefLabelProperty'
+          previousPage: 'hydra:previous'
+          Resource: 'rdfs:Resource'
+          rights: 'dcterms:rights'
+          sampleQueries: 'mod:sampleQueries'
+          SemanticArtefactDistribution: 'mod:SemanticArtefactDistribution'
+          spatialResolutionInMeters: 'dcat:spatialResolutionInMeters'
+          string: 'xsd:string'
+          synonymProperty: 'mod:synonymProperty'
+          temporalResolution: 'dcat:temporalResolution'
+          title: 'dcterms:title'
+          totalItems: 'hydra:totalItems'
+          usedEngineeringMethodology: 'mod:usedEngineeringMethodology'
+          useGuidelines: 'cc:useGuidelines'
+          valid: 'dcterms:valid'
+          view: 'hydra:view'
+
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': >-
+              https://example.org/SemanticArtefactDistribution/SemanticArtefactDistributionID
+            '@type': SemanticArtefactDistribution
+            accessService:
+                '@id': 'https://example.org/DataService/DataServiceID'
+                '@type': DataService
+            accessRights: string
+            accessURL:
+              '@id': 'https://example.org/Resource/AccessURLResourceID'
+              '@type': Resource
+            byteSize: string
+            compressFormat: string
+            conformsTo: string
+            description:
+              '@type': Literal
+              '@value': Lorem ipsum
+            downloadURL:
+              '@id': 'https://example.org/Resource/DownloadURLResourceID'
+              '@type': rdfs:Resource
+            format: string
+            hasPolicy:
+              '@id': 'https://example.org/Policy/PolicyID'
+              '@type': Policy
+            issued:
+              '@type': Literal
+              '@value': Lorem ipsum
+            license: string
+            mediaType: string
+            modified:
+              '@type': Literal
+              '@value': Lorem ipsum
+            packageFormat: string
+            rights: string
+            spatialResolutionInMeters: string
+            temporalResolution: string
+            title:
+              '@type': Literal
+              '@value': Lorem ipsum
+            useGuidelines:
+              '@id': 'https://example.org/Resource/UseGuidelinesResourceID'
+              '@type': Resource
+            created:
+              '@type': Literal
+              '@value': Lorem ipsum
+            dateSubmitted:
+              '@type': Literal
+              '@value': Lorem ipsum
+            dcterms:valid:
+              '@type': Literal
+              '@value': Lorem ipsum
+            authorProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/authorProperty'
+            averageChildCount:
+              '@type': decimal
+              '@value': 4
+            browsingUI:
+              '@type': anyURI
+              '@value': 'https://example.org/browsingUI'
+            classesWithMoreThan25Children:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            classesWithNoAuthorMetadata:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            classesWithNoDateMetadata:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            classesWithNoDefinition:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            classesWithNoFormalDefinition:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            classesWithNoLabel:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            classesWithOneChild:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            conformsToKnowledgeRepresentationParadigm:
+              '@id': 'https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID'
+              '@type': KnowledgeRepresentationParadigm
+            createdProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/createdProperty'
+            definitionProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/definitionProperty'
+            fairAssessment:
+              '@id': 'https://example.org/FairAssessment/FairAssessmentID'
+              '@type': FairAssessment
+            fairScore:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            hasFormalityLevel:
+              '@type': string
+              '@value': Lorem ipsum
+            hasRepresentationLanguage:
+              '@type': string
+              '@value': Lorem ipsum
+            hasSyntax:
+              '@type': anyURI
+              '@value': 'https://example.org/hasSyntax'
+            hierarchyProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/hierarchyProperty'
+            maxChildCount:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            maxDepth:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            metadataVoc:
+              '@type': anyURI
+              '@value': 'https://example.org/metadataVoc'
+            metrics:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            modifiedProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/modifiedProperty'
+            numberOfAxioms:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfClasses: 0
+            numberOfDataProperties:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfDeprecated:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfIndividuals:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfLabels:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfMappings:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfObjectProperties:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfProperties:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            obsoleteParent:
+              '@type': anyURI
+              '@value': 'https://example.org/obsoleteParent'
+            obsoleteProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/obsoleteProperty'
+            prefLabelProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/prefLabelProperty'
+            sampleQueries:
+              '@type': anyURI
+              '@value': 'https://example.org/sampleQueries'
+            synonymProperty:
+              '@type': anyURI
+              '@value': 'https://example.org/synonymProperty'
+            usedEngineeringMethodology:
+              '@id': 'https://example.org/EngineeringMethodology/EngineeringMethodologyID'
+              '@type': EngineeringMethodology
+            deprecated:
+              '@id': 'https://example.org/Resource/DeprecatedResourceID'
+              '@type': Resource
+            imports:
+              '@id': 'https://example.org/Ontology/OntologyID'
+              '@type': Ontology
+            curatedOn:
+              '@type': date
+            endpoint: string
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
     skosCollections:
       summary: Collections
       value:
@@ -2586,14 +3169,26 @@ components:
         dcat:accessService:
           title: access service
           description: A data service that gives access to the distribution of the dataset
-          $ref: "#/components/schemas/dcatDataService"
+          type: array
+          items:
+            type: object
+            properties:
+              '@id':
+                example: https://example.org/DataService/DataServiceID
+              '@type':
+                example: dcat:DataService
         dcterms:accessRights:
           title: access rights
           description: A rights statement that concerns how the distribution is accessed.
         dcat:accessURL:
           title: access URL
           description: A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.
-          $ref: "#/components/schemas/rdfsResource"
+          type: object
+          properties:
+            '@id':
+              example: https://example.org/Resource/AccessURLResourceID
+            '@type':
+              example: rdfs:Resource
         dcat:byteSize:
           title: byte size
           description: The size of a distribution in bytes.
@@ -2606,11 +3201,21 @@ components:
         dcterms:description:
           title: description
           description: A free-text account of the distribution.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
         dcat:downloadURL:
           title: download URL
           description: The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dcterms:format and/or dcat:mediaType
-          $ref: "#/components/schemas/rdfsResource"
+          type: object
+          properties:
+            '@id':
+              example: https://example.org/Resource/DownloadURLResourceID
+            '@type':
+              example: rdfs:Resource
         dcterms:format:
           title: format
           description: The file format of the distribution.
@@ -2626,7 +3231,12 @@ components:
         dcterms:issued:
           title: release date
           description: Date of formal issuance (e.g., publication) of the distribution.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
         dcterms:license:
           title: license
           description: A legal document under which the distribution is made available.
@@ -2636,7 +3246,12 @@ components:
         dcterms:modified:
           title: update/modification date
           description: Most recent date on which the distribution was changed, updated or modified.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
         dcat:packageFormat:
           title: packaging format
           description: The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.
@@ -2652,7 +3267,12 @@ components:
         dcterms:title:
           title: title
           description: A name given to the distribution.
-          $ref: "#/components/schemas/rdfsLiteral"
+          type: object
+          properties:
+            '@type':
+              example: rdfs:Literal
+            '@value':
+              example: Lorem ipsum
 
     # see https://www.w3.org/TR/vocab-dcat-2/#Class:Resource
     dcatResource:
@@ -2749,9 +3369,17 @@ components:
         dcterms:rights:
           title: rights
           description: A statement that concerns all rights not addressed with dcterms:license or dcterms:accessRights, such as copyright statements.
-        dcterms:subject:
+        dcat:theme:
           title: theme/category
           description: A main category of the resource. A resource can have multiple themes.
+          type: array
+          items:
+            type: object
+            properties:
+              '@id':
+                example: https://example.org/Resource/ThemeResourceID
+              '@type':
+                example: rdfs:Resource
         dcterms:title:
           title: title
           description: A name given to the item.
@@ -3566,23 +4194,48 @@ components:
             cc:useGuidelines:
               title: use guidelines
               description: A related resource which defines non-binding use guidelines for the work.
-              $ref: "#/components/schemas/rdfsResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/Resource/UseGuidelinesResourceID
+                '@type':
+                  example: rdfs:Resource
             dcterms:created:
               title: creation date
               description: Date of creation of the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:dateSubmitted:
               title: submission date
               description: Date of submission of the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:valid:
               title: validity date
               description: Date (often a range) of validity of a resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             mod:authorProperty:
               title: object author property
               description: Property used to specify objects's author.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/authorProperty
             mod:averageChildCount:
               title: average number of children per class
               description: Average number of children per class (BioPortal definition).
@@ -3595,35 +4248,75 @@ components:
             mod:browsingUI:
               title: browsing user interface
               description: The user interface (URL) where the ontology may be browsed or searched.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/browsingUI
             mod:classesWithMoreThan25Children:
               title: number of classes with more than 25 children
               description: Number of classes that have more than 25 direct subclasses.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:classesWithNoAuthorMetadata:
               title: number of classes with no author metadata
               description: Number of classes with author metadata.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:classesWithNoDateMetadata:
               title: number of classes with no date metadata
               description: Number of classes with no date metadata.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:classesWithNoDefinition:
               title: number of classes with no definition
               description: Number of classes that have no value for the definition property.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:classesWithNoFormalDefinition:
               title: number of classes with no formal or logical definition
               description: Number of classes with no formal or logical definition.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:classesWithNoLabel:
               title: number of classes with no label
               description: Number of classes with no labels.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:classesWithOneChild:
               title: number of classes with a single child
               description: Number of classes that have only one subclass in the is-a hierarchy.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:conformsToKnowledgeRepresentationParadigm:
               title: knowledge representation paradigm
               description: A representation formalism that is followed to describe knowledge in an ontology. Example includes description logics, first order logic, etc. 
@@ -3636,11 +4329,21 @@ components:
             mod:createdProperty:
               title: object creation date property
               description: Property used to specify the date of creation of a class or another object in the ontology.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/createdProperty
             mod:definitionProperty:
               title: object definition property
               description: Property used to specify objects' definition.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/definitionProperty
             mod:fairAssessment:
               title: FAIR assessment
               description: A FAIRness assessment result produced by a known or identified FAIRness assessment method or tool. It can be either a simple number or a structured result document explaining the assessment.
@@ -3653,46 +4356,101 @@ components:
             mod:fairScore:
               title: FAIR assessment
               description: A FAIRness assessment result produced by a known or identified FAIRness assessment method or tool. It can be either a simple number or a structured result document explaining the assessment.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:hasFormalityLevel:
               title: formality level
               description: The level of formality of an ontology.
-              $ref: "#/components/schemas/xsdString"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:string
+                '@value':
+                  example: Lorem ipsum
             mod:hasRepresentationLanguage:
               title: representation language
               description: A language that is used to create an ontology.
-              $ref: "#/components/schemas/xsdString"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:string
+                '@value':
+                  example: Lorem ipsum
             mod:hasSyntax:
               title: syntax
               description: The syntax followed in the creation of an ontology.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/hasSyntax
             mod:hierarchyProperty:
               title: transitive hierarchy property
               description: Property used to specify the hierarchy (e.g. rdfs:subClassOf or skos:broader).
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/hierarchyProperty
             mod:maxChildCount:
               title: maximum number of children per class
               description: Maximum number of children per class (BioPortal definition).
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:maxDepth:
               title: maximum depth of the hierachy
               description: Maximum depth of the hierarchy tree.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:metadataVoc:
               title: metadata vocabulary used
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/metadataVoc
             mod:metrics:
               title: metrics
               description: A generic property to store any metrics (number) related to the ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:modifiedProperty:
               title: object modification date property
               description: Property used to specify the date of modification of a class or another object in the ontology.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/modifiedProperty
             mod:numberOfAxioms:
               title: number of axioms or triples
               description: The total number of axioms in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfClasses:
               title: number of classes
               description: The total number of classes in an ontology.
@@ -3700,51 +4458,111 @@ components:
             mod:numberOfDataProperties:
               title: number of data properties
               description: The total number of data properties in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfDeprecated:
               title: number of deprecated objects
               description: The total number of  in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfIndividuals:
               title: number of individuals
               description: The total number of individuals in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfLabels:
               title: number of labels
               description: Number of defined labels for any resources in an ontology (classes, properties, etc).
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfMappings:
               title: number of mappings
               description: Number of mappings within a given semantic artefact or semantic artefact catalogue.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfObjectProperties:
               title: number of object properties
               description: The total number of object properties in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:numberOfProperties:
               title: number of properties
               description: The total number of properties in an ontology.
-              $ref: "#/components/schemas/xsdNonNegativeInteger"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:nonNegativeInteger
+                '@value':
+                  example: 5436
             mod:obsoleteParent:
               title: root of obsolete branch
               description: Property used to specify the root of an obsolete branch in the ontology.  
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/obsoleteParent
             mod:obsoleteProperty:
               title: object obsolete property
               description: Property used to specify obsolete objects.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/obsoleteProperty
             mod:prefLabelProperty:
               title: object preferred label property
               description: Property used to specify objects' preferred label.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/prefLabelProperty
             mod:sampleQueries:
               title: sample queries
               description: A set of queries (may be SPARQL, DL Queries) that are provided along with an ontology.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/sampleQueries
             mod:synonymProperty:
               title: object synonym property
               description: Property used to specify objects' synonyms.
-              $ref: "#/components/schemas/xsdAnyURI"
+              type: object
+              properties:
+                '@type':
+                  example: xsd:anyURI
+                '@value':
+                  example: https://example.org/synonymProperty
             mod:usedEngineeringMethodology:
               title: engineering methodology
               description: A methodolgy following which an ontology is created.
@@ -3757,7 +4575,12 @@ components:
             owl:deprecated:
               title: deprecated
               description: The annotation property that indicates that a given entity has been deprecated.
-              $ref: "#/components/schemas/rdfsResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/Resource/DeprecatedResourceID
+                '@type':
+                  example: rdfs:Resource
             owl:imports:
               title: imports
               description: References another OWL ontology containing definitions, whose meaning is considered to be part of the meaning of the importing ontology.

--- a/mod_api/static/mod_api/openapi.yaml
+++ b/mod_api/static/mod_api/openapi.yaml
@@ -602,6 +602,10 @@ components:
         text/turtle:
           schema:
             type: string
+          examples:
+            semanticArtefactCatalogRecord:
+              summary: Semantic Artefact Catalog Record
+              externalValue: "./ttl/record.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -609,7 +613,10 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            semanticArtefactCatalogRecord:
+              summary: Semantic Artefact Catalog Record
+              externalValue: "./xml/record.xml"
 
     records:
       description: "OK"
@@ -645,9 +652,11 @@ components:
               $ref: "#/components/schemas/html"
         text/turtle:
           schema:
-            type: array
-            items:
-              type: string
+            type: string
+          examples:
+            semanticArtefactCatalogRecords:
+              summary: Semantic Artefact Catalog Records
+              externalValue: "./ttl/records.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -655,7 +664,10 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            semanticArtefactCatalogRecords:
+              summary: Semantic Artefact Catalog Records
+              externalValue: "./xml/records.xml"
 
     resource:
       description: "OK"
@@ -1857,51 +1869,25 @@ components:
           dcterms: 'http://purl.org/dc/terms/'
           foaf: 'http://xmlns.com/foaf/0.1/'
           mod: 'https://w3id.org/mod#'
-          odrl: 'http://www.w3.org/ns/odrl/2/'
           pav: 'http://purl.org/pav/'
-          prov: 'http://www.w3.org/ns/prov#'
           rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
-          skos: 'http://www.w3.org/2004/02/skos/core#'
-          vcard: 'http://www.w3.org/2006/vcard/ns#'
           xsd: 'http://www.w3.org/2001/XMLSchema#'
-          accessRights: 'dcterms:accessRights'
-          Attribution: 'prov:Attribution'
           conformsTo: 'dcterms:conformsTo'
-          contactPoint: 'dcat:contactPoint'
           created: 'dcterms:created'
-          creator: 'dcterms:creator'
           curatedBy: 'pav:curatedBy'
           curatedOn: 'pav:curatedOn'
           date: 'xsd:date'
           dateSubmitted: 'dcterms:dateSubmitted'
           description: 'dcterms:description'
           Document: 'foaf:Document'
-          fn: 'vcard:fn'
-          hasPolicy: 'odrl:hasPolicy'
           homepage: 'foaf:homepage'
-          identifier: 'dcterms:identifier'
-          isReferencedBy: 'dcterms:isReferencedBy'
           issued: 'dcterms:issued'
-          keyword: 'dcat:keyword'
-          Kind: 'vcard:Kind'
-          landingPage: 'dcat:landingPage'
-          language: 'dcterms:language'
-          license: 'dcterms:license'
           Literal: 'rdfs:Literal'
           modified: 'dcterms:modified'
-          nickname: 'vcard:nickname'
-          nonNegativeInteger: 'xsd:nonNegativeInteger'
-          Policy: 'odrl:Policy'
           primaryTopic: 'foaf:primaryTopic'
-          publisher: 'dcterms:publisher'
-          qualifiedAttribution: 'prov:qualifiedAttribution'
-          qualifiedRelation: 'dcat:qualifiedRelation'
-          relation: 'dcterms:relation'
-          rights: 'dcterms:rights'
+          Resource: 'dcat:Resource'
           SemanticArtefactCatalogRecord: 'mod:SemanticArtefactCatalogRecord'
-          subject: 'dcterms:subject'
           title: 'dcterms:title'
-          type: 'dcterms:type'
         '@id': >-
           https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID
         '@type': SemanticArtefactCatalogRecord
@@ -1919,46 +1905,8 @@ components:
           '@type': Literal
           '@value': Lorem ipsum
         primaryTopic:
-          accessRights: string
-          conformsTo: string
-          contactPoint:
-            '@id': 'https://example.org/vcardKind/vcardKindID'
-            '@type': Kind
-            fn: Corky Crystal
-            nickname: Corks
-          creator: string
-          description:
-            '@type': Literal
-            '@value': Lorem ipsum
-          hasPolicy:
-            '@id': 'https://example.org/Policy/PolicyID'
-            '@type': Policy
-          identifier:
-            '@type': Literal
-            '@value': Lorem ipsum
-          isReferencedBy: string
-          issued: string
-          keyword: string
-          landingPage:
-            '@id': 'https://example.org/Document/DocumentID'
-            '@type': Document
-          language: string
-          license: string
-          modified:
-            '@type': Literal
-            '@value': Lorem ipsum
-          publisher: string
-          qualifiedAttribution:
-            '@id': 'https://example.org/Attribution/AttributionID'
-            '@type': Attribution
-          qualifiedRelation: string
-          relation: string
-          rights: string
-          subject: string
-          title:
-            '@type': Literal
-            '@value': Lorem ipsum
-          type: string
+          '@id': 'https://example.org/dcatResource/dcatResourceID'
+          '@type': Resource
         dateSubmitted:
           '@type': Literal
           '@value': Lorem ipsum
@@ -1981,20 +1929,12 @@ components:
           foaf: 'http://xmlns.com/foaf/0.1/'
           hydra: 'http://www.w3.org/ns/hydra/core#'
           mod: 'https://w3id.org/mod#'
-          odrl: 'http://www.w3.org/ns/odrl/2/'
           pav: 'http://purl.org/pav/'
-          prov: 'http://www.w3.org/ns/prov#'
           rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
-          skos: 'http://www.w3.org/2004/02/skos/core#'
-          vcard: 'http://www.w3.org/2006/vcard/ns#'
           xsd: 'http://www.w3.org/2001/XMLSchema#'
-          accessRights: 'dcterms:accessRights'
-          Attribution: 'prov:Attribution'
           Collection: 'hydra:Collection'
           conformsTo: 'dcterms:conformsTo'
-          contactPoint: 'dcat:contactPoint'
           created: 'dcterms:created'
-          creator: 'dcterms:creator'
           curatedBy: 'pav:curatedBy'
           curatedOn: 'pav:curatedOn'
           date: 'xsd:date'
@@ -2002,39 +1942,22 @@ components:
           description: 'dcterms:description'
           Document: 'foaf:Document'
           firstPage: 'hydra:first'
-          fn: 'vcard:fn'
-          hasPolicy: 'odrl:hasPolicy'
           homepage: 'foaf:homepage'
-          identifier: 'dcterms:identifier'
-          isReferencedBy: 'dcterms:isReferencedBy'
           issued: 'dcterms:issued'
           itemsPerPage: 'hydra:itemsPerPage'
-          keyword: 'dcat:keyword'
-          Kind: 'vcard:Kind'
-          landingPage: 'dcat:landingPage'
-          language: 'dcterms:language'
           lastPage: 'hydra:last'
-          license: 'dcterms:license'
           Literal: 'rdfs:Literal'
           member: 'hydra:member'
           modified: 'dcterms:modified'
           nextPage: 'hydra:next'
-          nickname: 'vcard:nickname'
           nonNegativeInteger: 'xsd:nonNegativeInteger'
           PartialCollectionView: 'hydra:PartialCollectionView'
-          Policy: 'odrl:Policy'
           previousPage: 'hydra:previous'
           primaryTopic: 'foaf:primaryTopic'
-          publisher: 'dcterms:publisher'
-          qualifiedAttribution: 'prov:qualifiedAttribution'
-          qualifiedRelation: 'dcat:qualifiedRelation'
-          relation: 'dcterms:relation'
-          rights: 'dcterms:rights'
+          Resource: 'dcat:Resource'
           SemanticArtefactCatalogRecord: 'mod:SemanticArtefactCatalogRecord'
-          subject: 'dcterms:subject'
           title: 'dcterms:title'
           totalItems: 'hydra:totalItems'
-          type: 'dcterms:type'
           view: 'hydra:view'
         '@id': 'https://example.org/collection/collectionID'
         '@type': Collection
@@ -2062,46 +1985,8 @@ components:
               '@type': Literal
               '@value': Lorem ipsum
             primaryTopic:
-              accessRights: string
-              conformsTo: string
-              contactPoint:
-                '@id': 'https://example.org/vcardKind/vcardKindID'
-                '@type': Kind
-                fn: Corky Crystal
-                nickname: Corks
-              creator: string
-              description:
-                '@type': Literal
-                '@value': Lorem ipsum
-              hasPolicy:
-                '@id': 'https://example.org/Policy/PolicyID'
-                '@type': Policy
-              identifier:
-                '@type': Literal
-                '@value': Lorem ipsum
-              isReferencedBy: string
-              issued: string
-              keyword: string
-              landingPage:
-                '@id': 'https://example.org/Document/DocumentID'
-                '@type': Document
-              language: string
-              license: string
-              modified:
-                '@type': Literal
-                '@value': Lorem ipsum
-              publisher: string
-              qualifiedAttribution:
-                '@id': 'https://example.org/Attribution/AttributionID'
-                '@type': Attribution
-              qualifiedRelation: string
-              relation: string
-              rights: string
-              subject: string
-              title:
-                '@type': Literal
-                '@value': Lorem ipsum
-              type: string
+              '@id': 'https://example.org/dcatResource/dcatResourceID'
+              '@type': Resource
             dateSubmitted:
               '@type': Literal
               '@value': Lorem ipsum
@@ -3086,23 +2971,48 @@ components:
             dcterms:description:
               title: Description
               description: A free-text account of the record.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:issued:
               title: listing date
               description: The date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:modified:
               title: update/modification date
               description: Most recent date on which the catalog entry was changed, updated or modified.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             dcterms:title:
               title: Title
               description: A name given to the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             foaf:primaryTopic:
               title: primary topic
               description: The Resource (dataset or service) described in the record.
-              $ref: "#/components/schemas/dcatResource"
+              type: object
+              properties:
+                '@id':
+                  example: https://example.org/dcatResource/dcatResourceID
+                '@type':
+                  example: dcat:Resource
 
     # see https://www.w3.org/TR/vocab-dcat-2/#Class:Data_Service
     dcatDataService:
@@ -4152,7 +4062,12 @@ components:
             dcterms:dateSubmitted:
               title: submission date
               description: Date of submission of the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             foaf:homepage:
               title: homepage
               description: An unambiguous reference to the resource within a given context.
@@ -4165,7 +4080,12 @@ components:
             dcterms:created:
               title: creation date
               description: Date of creation of the resource.
-              $ref: "#/components/schemas/rdfsLiteral"
+              type: object
+              properties:
+                '@type':
+                  example: rdfs:Literal
+                '@value':
+                  example: Lorem ipsum
             pav:curatedBy:
               title: curator
               description: A curator who restructure the previously authored content and shape it to be appropriate for the intended representation (e.g. by normalizing the fields for being represented in a spreadsheet).

--- a/mod_api/static/mod_api/openapi.yaml
+++ b/mod_api/static/mod_api/openapi.yaml
@@ -155,14 +155,21 @@ components:
             properties:
               '@context':
                 $ref: "#/components/schemas/Context"
-              mod:SemanticArtefact:
-                $ref: "#/components/schemas/modSemanticArtefact"
+            allOf:
+              - $ref: "#/components/schemas/modSemanticArtefact"
+          examples:
+            semanticArtefact:
+              $ref: "#/components/examples/semanticArtefact"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
-            $ref: "./sa_ttl.yaml"
+            type: string
+          examples:
+            semanticArtefact:
+              summary: Semantic Artefact
+              externalValue: "./ttl/artefact.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -170,8 +177,10 @@ components:
               name: rdf
               wrapped: true
             items:
-              type: string
-              example: In progress
+          examples:
+            semanticArtefact:
+              summary: Semantic Artefact
+              externalValue: "./xml/artefact.xml"
 
     artefacts:
       description: "OK"
@@ -197,14 +206,19 @@ components:
                   $ref: "#/components/schemas/modSemanticArtefact"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            semanticArtefacts:
+              $ref: "#/components/examples/semanticArtefacts"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
-            type: array
-            items:
-              $ref: "./sa_ttl.yaml"
+            type: string
+          examples:
+            semanticArtefacts:
+              summary: Semantic Artefacts
+              externalValue: "./ttl/artefacts.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -212,8 +226,10 @@ components:
               name: rdf
               wrapped: true
             items:
-              type: string
-              example: In progress
+          examples:
+            semanticArtefacts:
+              summary: Semantic Artefacts
+              externalValue: "./xml/artefacts.xml"
 
     catalog:
       description: "OK"
@@ -225,8 +241,8 @@ components:
             properties:
               '@context':
                 $ref: "#/components/schemas/Context"
-              mod:SemanticArtefactCatalog:
-                $ref: "#/components/schemas/modSemanticArtefactCatalog"
+            allOf:
+              - $ref: "#/components/schemas/modSemanticArtefactCatalog"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
@@ -266,12 +282,18 @@ components:
                   $ref: "#/components/schemas/owlClass"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            owlClasses:
+              $ref: "#/components/examples/owlClasses"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            owlClasses:
+              externalValue: "./ttl/classes.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -279,7 +301,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            owlClasses:
+              externalValue: "./xml/classes.xml"
 
     collections:
       description: "OK"
@@ -305,12 +329,18 @@ components:
                   $ref: "#/components/schemas/skosCollection"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            skosCollection:
+              $ref: "#/components/examples/skosCollections"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            skosCollection:
+              externalValue: "./ttl/collections.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -318,7 +348,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            skosCollection:
+              externalValue: "./xml/collections.xml"
 
     concepts:
       description: "OK"
@@ -344,12 +376,18 @@ components:
                   $ref: "#/components/schemas/skosConcept"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            skosConcept:
+              $ref: "#/components/examples/skosConcepts"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            skosCollection:
+              externalValue: "./ttl/concepts.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -357,7 +395,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            skosCollection:
+              externalValue: "./xml/concepts.xml"
 
     distribution:
       description: "OK"
@@ -369,8 +409,8 @@ components:
             properties:
               '@context':
                 $ref: "#/components/schemas/Context"
-              mod:SemanticArtefactDistribution:
-                $ref: "#/components/schemas/modSemanticArtefactDistribution"
+            allOf:
+              - $ref: "#/components/schemas/modSemanticArtefactDistribution"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
@@ -453,12 +493,18 @@ components:
                   $ref: "#/components/schemas/owlNamedIndividual"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            owlNamedIndividual:
+              $ref: "#/components/examples/owlNamedIndividuals"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            skosCollection:
+              externalValue: "./ttl/individuals.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -466,7 +512,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            skosCollection:
+              externalValue: "./xml/individuals.xml"
 
     properties:
       description: "OK"
@@ -492,12 +540,18 @@ components:
                   $ref: "#/components/schemas/rdfsProperty"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            rdfsProperty:
+              $ref: "#/components/examples/rdfsProperties"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            skosCollection:
+              externalValue: "./ttl/properties.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -505,7 +559,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            skosCollection:
+              externalValue: "./xml/properties.xml"
 
     record:
       description: "OK"
@@ -517,8 +573,11 @@ components:
             properties:
               '@context':
                 $ref: "#/components/schemas/Context"
-              mod:SemanticArtefactCatalogRecord:
-                $ref: "#/components/schemas/modSemanticArtefactCatalogRecord"
+            allOf:
+              - $ref: "#/components/schemas/modSemanticArtefactCatalogRecord"
+          examples:
+            record:
+              $ref: "#/components/examples/semanticArtefactCatalogRecord"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
@@ -558,6 +617,9 @@ components:
                   $ref: "#/components/schemas/modSemanticArtefactCatalogRecord"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            records:
+              $ref: "#/components/examples/semanticArtefactCatalogRecords"
         text/html:
           schema:
             type: array
@@ -585,12 +647,18 @@ components:
             type: object
             title: RDFS Resource
             $ref: "#/components/schemas/rdfsResource"
+          examples:
+            rdfsResource:
+              $ref: "#/components/examples/rdfsResource"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            skosCollection:
+              externalValue: "./ttl/resource.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -598,7 +666,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            skosCollection:
+              externalValue: "./xml/resource.xml"
 
     resources:
       description: "OK"
@@ -624,12 +694,18 @@ components:
                   $ref: "#/components/schemas/rdfsResource"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            rdfsResource:
+              $ref: "#/components/examples/rdfsResources"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            skosCollection:
+              externalValue: "./ttl/resources.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -637,7 +713,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            skosCollection:
+              externalValue: "./xml/resources.xml"
 
     schemes:
       description: "OK"
@@ -663,12 +741,18 @@ components:
                   $ref: "#/components/schemas/skosScheme"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            skosScheme:
+              $ref: "#/components/examples/skosSchemes"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
         text/turtle:
           schema:
             type: string
+          examples:
+            skosCollection:
+              externalValue: "./ttl/schemes.ttl"
         application/rdf+xml:
           schema:
             type: array
@@ -676,7 +760,9 @@ components:
               name: rdf
               wrapped: true
             items:
-              example: In progress
+          examples:
+            skosCollection:
+              externalValue: "./xml/schemes.xml"
 
     searchResult:
       description: "OK"
@@ -731,6 +817,23 @@ components:
                       $ref: "#/components/schemas/skosScheme"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            owlClass:
+              $ref: "#/components/examples/owlClasses"
+            skosCollection:
+              $ref: "#/components/examples/skosCollections"
+            skosConcept:
+              $ref: "#/components/examples/skosConcepts"
+            owlNamedIndividual:
+              $ref: "#/components/examples/owlNamedIndividuals"
+            rdfsProperty:
+              $ref: "#/components/examples/rdfsProperties"
+            rdfsResource:
+              $ref: "#/components/examples/rdfsResources"
+            skosScheme:
+              $ref: "#/components/examples/skosSchemes"
+            semanticArtefacts:
+              $ref: "#/components/examples/semanticArtefacts"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
@@ -795,6 +898,21 @@ components:
                       $ref: "#/components/schemas/skosScheme"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            owlClass:
+              $ref: "#/components/examples/owlClasses"
+            skosCollection:
+              $ref: "#/components/examples/skosCollections"
+            skosConcept:
+              $ref: "#/components/examples/skosConcepts"
+            owlNamedIndividual:
+              $ref: "#/components/examples/owlNamedIndividuals"
+            rdfsProperty:
+              $ref: "#/components/examples/rdfsProperties"
+            rdfsResource:
+              $ref: "#/components/examples/rdfsResources"
+            skosScheme:
+              $ref: "#/components/examples/skosSchemes"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
@@ -834,6 +952,9 @@ components:
                     $ref: "#/components/schemas/modSemanticArtefact"
               view:
                 $ref: "#/components/schemas/view"
+          examples:
+            semanticArtefacts:
+              $ref: "#/components/examples/semanticArtefacts"
         text/html:
           schema:
             $ref: "#/components/schemas/html"
@@ -855,6 +976,1347 @@ components:
         text/html:
           schema:
             $ref: "#/components/schemas/error_message"
+
+  examples:
+    owlClasses:
+      summary: Classes
+      value:
+        '@context':
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          owl: 'http://www.w3.org/2002/07/owl#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          Class: 'owl:Class'
+          Collection: 'hydra:Collection'
+          firstPage: 'hydra:first'
+          itemsPerPage: 'hydra:itemsPerPage'
+          lastPage: 'hydra:last'
+          member: 'hydra:member'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          previousPage: 'hydra:previous'
+          totalItems: 'hydra:totalItems'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/Class/ClassID1'
+            '@type': Class
+          - '@id': 'https://example.org/Class/ClassID2'
+            '@type': Class
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+    owlNamedIndividuals:
+      summary: Named Individuals
+      value:
+        '@context':
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          owl: 'http://www.w3.org/2002/07/owl#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          Collection: 'hydra:Collection'
+          firstPage: 'hydra:first'
+          itemsPerPage: 'hydra:itemsPerPage'
+          lastPage: 'hydra:last'
+          member: 'hydra:member'
+          NamedIndividual: 'owl:NamedIndividual'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          previousPage: 'hydra:previous'
+          totalItems: 'hydra:totalItems'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/NamedIndividual/NamedIndividualID1'
+            '@type': NamedIndividual
+          - '@id': 'https://example.org/NamedIndividual/NamedIndividualID2'
+            '@type': NamedIndividual
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+
+    semanticArtefact:
+      summary: Semantic Artefact
+      value:
+        '@context':
+          adms: 'http://www.w3.org/ns/adms#'
+          cc: 'http://creativecommons.org/ns#'
+          dc: 'http://purl.org/dc/elements/1.1/'
+          dcat: 'http://www.w3.org/ns/dcat#'
+          dcterms: 'http://purl.org/dc/terms/'
+          doap: 'http://usefulinc.com/ns/doap#'
+          foaf: 'http://xmlns.com/foaf/0.1/'
+          ical: 'http://www.w3.org/2002/12/cal/ical#'
+          mod: 'https://w3id.org/mod#'
+          odrl: 'http://www.w3.org/ns/odrl/2/'
+          owl: 'http://www.w3.org/2002/07/owl#'
+          pav: 'http://purl.org/pav/'
+          prov: 'http://www.w3.org/ns/prov#'
+          rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          schema: 'https://schema.org/'
+          sd: 'http://www.w3.org/ns/sparql-service-description#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          vann: 'https://vocab.org/vann/'
+          vcard: 'http://www.w3.org/2006/vcard/ns#'
+          void: 'http://rdfs.org/ns/void#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          abstract: 'dcterms:abstract'
+          accessRights: 'dcterms:accessRights'
+          accrualMethod: 'dcterms:accrualMethod'
+          accrualPeriodicity: 'dcterms:accrualPeriodicity'
+          accrualPolicy: 'dcterms:accrualPolicy'
+          acronym: 'mod:acronym'
+          Activity: 'prov:Activity'
+          alternative: 'dcterms:alternative'
+          analytics: 'mod:analytics'
+          Analytics: 'mod:Analytics'
+          anyURI: 'xsd:anyURI'
+          associatedMedia: 'schema:associatedMedia'
+          Attribution: 'prov:Attribution'
+          audience: 'dcterms:audience'
+          award: 'schema:award'
+          backwardCompatibleWith: 'owl:backwardCompatibleWith'
+          bibliographicCitation: 'dcterms:bibliographicCitation'
+          bug-database: 'doap:bug-database'
+          changes: 'vann:changes'
+          classPartition: 'void:classPartition'
+          comesFromTheSameDomain: 'mod:comesFromTheSameDomain'
+          comment: 'rdfs:comment'
+          competencyQuestion: 'mod:competencyQuestion'
+          conformsTo: 'dcterms:conformsTo'
+          contactPoint: 'dcat:contactPoint'
+          contributor: 'dcterms:contributor'
+          coverage: 'dcterms:coverage'
+          createdWith: 'pav:createdWith'
+          creator: 'dcterms:creator'
+          curatedBy: 'pav:curatedBy'
+          dataset: 'void:dataset'
+          depiction: 'foaf:depiction'
+          deprecated: 'owl:deprecated'
+          description: 'dcterms:description'
+          designedForTask: 'mod:designedForTask'
+          Document: 'foaf:Document'
+          endorsedBy: 'mod:endorsedBy'
+          Evaluation: 'mod:Evaluation'
+          example: 'vann:example'
+          exampleResource: 'void:exampleResource'
+          fn: 'vcard:fn'
+          fundedBy: 'foaf:fundedBy'
+          funding: 'schema:funding'
+          generalizes: 'mod:generalizes'
+          group: 'mod:group'
+          Group: 'mod:Group'
+          hasDisjunctionsWith: 'mod:hasDisjunctionsWith'
+          hasDisparateModelling: 'mod:hasDisparateModelling'
+          hasEquivalencesWith: 'mod:hasEquivalencesWith'
+          hasEvaluation: 'mod:hasEvaluation'
+          hasFormat: 'dcterms:hasFormat'
+          hasPart: 'dcterms:hasPart'
+          hasPolicy: 'odrl:hasPolicy'
+          hasVersion: 'dcterms:hasVersion'
+          hiddenLabel: 'skos:hiddenLabel'
+          homepage: 'foaf:homepage'
+          identifier: 'dcterms:identifier'
+          Image: 'foaf:Image'
+          includedInDataCatalog: 'schema:includedInDataCatalog'
+          incompatibleWith: 'owl:incompatibleWith'
+          isFormatOf: 'dcterms:isFormatOf'
+          isPartOf: 'dcterms:isPartOf'
+          isReferencedBy: 'dcterms:isReferencedBy'
+          issued: 'dcterms:issued'
+          keyword: 'dcat:keyword'
+          Kind: 'vcard:Kind'
+          knownUsage: 'mod:knownUsage'
+          landingPage: 'dcat:landingPage'
+          language: 'dcterms:language'
+          license: 'dcterms:license'
+          Literal: 'rdfs:Literal'
+          logo: 'foaf:logo'
+          mailing-list: 'doap:mailing-list'
+          metrics: 'mod:metrics'
+          modified: 'dcterms:modified'
+          morePermissions: 'cc:morePermissions'
+          nickname: 'vcard:nickname'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          numberOfAgents: 'mod:numberOfAgents'
+          numberOfEndorsements: 'mod:numberOfEndorsements'
+          numberOfEvaluations: 'mod:numberOfEvaluations'
+          numberOfNotes: 'mod:numberOfNotes'
+          numberOfUsers: 'mod:numberOfUsers'
+          numberOfUsingProjects: 'mod:numberOfUsingProjects'
+          Ontology: 'owl:Ontology'
+          openSearchDescription: 'void:openSearchDescription'
+          preferredNamespacePrefix: 'vann:preferredNamespacePrefix'
+          preferredNamespaceUri: 'vann:preferredNamespaceUri'
+          primaryTopic: 'foaf:primaryTopic'
+          priorVersion: 'owl:priorVersion'
+          Project: 'foaf:Project'
+          propertyPartition: 'void:propertyPartition'
+          publisher: 'dcterms:publisher'
+          qualifiedAttribution: 'prov:qualifiedAttribution'
+          qualifiedRelation: 'dcat:qualifiedRelation'
+          relation: 'dcterms:relation'
+          reliesOn: 'mod:reliesOn'
+          repository: 'doap:repository'
+          Resource: 'rdfs:Resource'
+          rights: 'dcterms:rights'
+          rightsHolder: 'dcterms:rightsHolder'
+          rootResource: 'void:rootResource'
+          SemanticArtefact: 'mod:SemanticArtefact'
+          semanticArtefactRelation: 'mod:semanticArtefactRelation'
+          SemanticArtefactTask: 'mod:SemanticArtefactTask'
+          similar: 'mod:similar'
+          source: 'dcterms:source'
+          specializes: 'mod:specializes'
+          status: 'mod:status'
+          string: 'xsd:string'
+          subject: 'dcterms:subject'
+          Thing: 'owl:Thing'
+          title: 'dcterms:title'
+          toDoList: 'mod:toDoList'
+          translationOfWork: 'schema:translationOfWork'
+          translator: 'schema:translator'
+          type: 'dcterms:type'
+          URI: 'mod:URI'
+          uriLookupEndpoint: 'void:uriLookupEndpoint'
+          uriRegexPattern: 'void:uriRegexPattern'
+          usedBy: 'mod:usedBy'
+          usedInProject: 'mod:usedInProject'
+          useGuidelines: 'cc:useGuidelines'
+          versionInfo: 'owl:versionInfo'
+          versionIRI: 'owl:versionIRI'
+          Vtodo: 'ical:Vtodo'
+          wasGeneratedBy: 'prov:wasGeneratedBy'
+          wasInvalidatedBy: 'prov:wasInvalidatedBy'
+          workTranslation: 'schema:workTranslation'
+
+        '@id': 'https://example.org/SemanticArtefact/SemanticArtefactID'
+        '@type': SemanticArtefact
+        accessRights: string
+        conformsTo: string
+        contactPoint:
+          '@id': 'https://example.org/vcardKind/vcardKindID'
+          '@type': Kind
+          fn: Corky Crystal
+          nickname: Corks
+        creator: string
+        description:
+          '@type': Literal
+          '@value': Lorem ipsum
+        hasPolicy:
+          '@id': 'https://example.org/Policy/PolicyID'
+          '@type': 'odrl:Policy'
+        identifier:
+          '@type': Literal
+          '@value': Lorem ipsum
+        isReferencedBy: string
+        issued: string
+        keyword: string
+        landingPage:
+          '@id': 'https://example.org/Document/DocumentID'
+          '@type': Document
+        language: string
+        license: string
+        modified:
+          '@type': Literal
+          '@value': Lorem ipsum
+        publisher: string
+        qualifiedAttribution:
+          '@id': 'https://example.org/Attribution/AttributionID'
+          '@type': Attribution
+        qualifiedRelation: string
+        relation: string
+        rights: string
+        subject: string
+        title:
+          '@type': Literal
+          '@value': Lorem ipsum
+        type: string
+        useGuidelines:
+          '@id': 'https://example.org/Resource/ResourceID'
+          '@type': Resource
+        morePermissions:
+          '@id': 'https://example.org/Resource/ResourceID'
+          '@type': Resource
+        primaryTopic:
+          '@id': 'https://example.org/Thing/ThingID'
+          '@type': Thing
+        abstract: string
+        accrualMethod: string
+        accrualPeriodicity: string
+        accrualPolicy: string
+        alternative:
+          '@type': Literal
+          '@value': Lorem ipsum
+        audience: string
+        bibliographicCitation:
+          '@type': Literal
+          '@value': Lorem ipsum
+        contributor: string
+        coverage: string
+        hasFormat: string
+        hasPart: string
+        hasVersion: string
+        isFormatOf: string
+        isPartOf: string
+        rightsHolder: string
+        source: string
+        bug-database: string
+        mailing-list: string
+        repository:
+          '@id': 'https://example.org/repository/repositoryID'
+          '@type': repository
+        depiction:
+          '@id': 'https://example.org/Image/ImageID'
+          '@type': Image
+        fundedBy:
+          '@id': 'https://example.org/Thing/ThingID'
+          '@type': Thing
+        homepage:
+          '@id': 'https://example.org/Document/DocumentID'
+          '@type': Document
+        logo:
+          '@id': 'https://example.org/Thing/ThingID'
+          '@type': Thing
+        acronym:
+          '@type': string
+          '@value': Lorem ipsum
+        analytics:
+          '@id': 'https://example.org/Analytics/AnalyticsID'
+          '@type': Analytics
+        comesFromTheSameDomain: string
+        competencyQuestion:
+          '@type': string
+          '@value': Lorem ipsum
+        designedForTask:
+          '@id': 'https://example.org/SemanticArtefactTask/SemanticArtefactTaskID'
+          '@type': SemanticArtefactTask
+        endorsedBy: string
+        generalizes: string
+        group:
+          '@id': 'https://example.org/Group/GroupID'
+          '@type': Group
+        hasDisjunctionsWith: string
+        hasDisparateModelling: string
+        hasEquivalencesWith: string
+        hasEvaluation:
+          '@id': 'https://example.org/Evaluation/EvaluationID'
+          '@type': Evaluation
+        knownUsage:
+          '@type': string
+          '@value': Lorem ipsum
+        metrics:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfAgents:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfEndorsements:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfEvaluations:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfNotes:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfUsers:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        numberOfUsingProjects:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        reliesOn: string
+        semanticArtefactRelation: string
+        similar: string
+        specializes: string
+        status:
+          '@type': string
+          '@value': Lorem ipsum
+        toDoList:
+          '@id': 'https://example.org/Vtodo/VtodoID'
+          '@type': Vtodo
+        URI:
+          '@type': anyURI
+          '@value': 'https://example.org'
+        usedBy: string
+        usedInProject:
+          '@id': 'https://example.org/Project/ProjectID'
+          '@type': Project
+        backwardCompatibleWith:
+          '@id': 'https://example.org/Ontology/OntologyID'
+          '@type': Ontology
+        deprecated:
+          '@id': 'https://example.org/Resource/ResourceID'
+          '@type': Resource
+        incompatibleWith:
+          '@id': 'https://example.org/Ontology/OntologyID'
+          '@type': Ontology
+        priorVersion:
+          '@id': 'https://example.org/Ontology/OntologyID'
+          '@type': Ontology
+        versionInfo:
+          '@type': string
+          '@value': Lorem ipsum
+        versionIRI:
+          '@id': 'https://example.org/Ontology/OntologyID'
+          '@type': Ontology
+        curatedBy: string
+        createdWith: string
+        wasGeneratedBy:
+          '@id': 'https://example.org/Activity/ActivityID'
+          '@type': Activity
+        wasInvalidatedBy:
+          '@id': 'https://example.org/Activity/ActivityID'
+          '@type': Activity
+        comment:
+          '@type': Literal
+          '@value': Lorem ipsum
+        associatedMedia: string
+        award: string
+        'schema:comment': string
+        funding: string
+        includedInDataCatalog: string
+        translationOfWork: string
+        translator: string
+        workTranslation: string
+        hiddenLabel:
+          '@type': Literal
+          '@value': Lorem ipsum
+        changes: string
+        example: string
+        preferredNamespacePrefix: string
+        preferredNamespaceUri: string
+        openSearchDescription:
+          '@id': 'https://example.org/Document/DocumentID'
+          '@type': Document
+        classPartition:
+          '@id': 'https://example.org/voidDataset/voidDatasetID'
+          '@type': dataset
+        exampleResource:
+          '@id': 'https://example.org/Resource/ResourceID'
+          '@type': Resource
+        rootResource:
+          '@id': 'https://example.org/Resource/ResourceID'
+          '@type': Resource
+        propertyPartition:
+          '@id': 'https://example.org/voidDataset/voidDatasetID'
+          '@type': dataset
+        uriLookupEndpoint:
+          '@type': anyURI
+          '@value': 'https://example.org'
+        uriRegexPattern: string
+
+    semanticArtefacts:
+      summary: Semantic Artefacts
+      value:
+        '@context':
+          adms: 'http://www.w3.org/ns/adms#'
+          cc: 'http://creativecommons.org/ns#'
+          dc: 'http://purl.org/dc/elements/1.1/'
+          dcat: 'http://www.w3.org/ns/dcat#'
+          dcterms: 'http://purl.org/dc/terms/'
+          doap: 'http://usefulinc.com/ns/doap#'
+          foaf: 'http://xmlns.com/foaf/0.1/'
+          ical: 'http://www.w3.org/2002/12/cal/ical#'
+          mod: 'https://w3id.org/mod#'
+          odrl: 'http://www.w3.org/ns/odrl/2/'
+          owl: 'http://www.w3.org/2002/07/owl#'
+          pav: 'http://purl.org/pav/'
+          prov: 'http://www.w3.org/ns/prov#'
+          rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          schema: 'https://schema.org/'
+          sd: 'http://www.w3.org/ns/sparql-service-description#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          vann: 'https://vocab.org/vann/'
+          vcard: 'http://www.w3.org/2006/vcard/ns#'
+          void: 'http://rdfs.org/ns/void#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          abstract: 'dcterms:abstract'
+          accessRights: 'dcterms:accessRights'
+          accrualMethod: 'dcterms:accrualMethod'
+          accrualPeriodicity: 'dcterms:accrualPeriodicity'
+          accrualPolicy: 'dcterms:accrualPolicy'
+          acronym: 'mod:acronym'
+          Activity: 'prov:Activity'
+          alternative: 'dcterms:alternative'
+          analytics: 'mod:analytics'
+          Analytics: 'mod:Analytics'
+          anyURI: 'xsd:anyURI'
+          associatedMedia: 'schema:associatedMedia'
+          Attribution: 'prov:Attribution'
+          audience: 'dcterms:audience'
+          award: 'schema:award'
+          backwardCompatibleWith: 'owl:backwardCompatibleWith'
+          bibliographicCitation: 'dcterms:bibliographicCitation'
+          bug-database: 'doap:bug-database'
+          changes: 'vann:changes'
+          classPartition: 'void:classPartition'
+          Collection: 'hydra:Collection'
+          comesFromTheSameDomain: 'mod:comesFromTheSameDomain'
+          comment: 'rdfs:comment'
+          competencyQuestion: 'mod:competencyQuestion'
+          conformsTo: 'dcterms:conformsTo'
+          contactPoint: 'dcat:contactPoint'
+          contributor: 'dcterms:contributor'
+          coverage: 'dcterms:coverage'
+          createdWith: 'pav:createdWith'
+          creator: 'dcterms:creator'
+          curatedBy: 'pav:curatedBy'
+          dataset: 'void:dataset'
+          depiction: 'foaf:depiction'
+          deprecated: 'owl:deprecated'
+          description: 'dcterms:description'
+          designedForTask: 'mod:designedForTask'
+          Document: 'foaf:Document'
+          endorsedBy: 'mod:endorsedBy'
+          Evaluation: 'mod:Evaluation'
+          example: 'vann:example'
+          exampleResource: 'void:exampleResource'
+          firstPage: 'hydra:first'
+          fn: 'vcard:fn'
+          fundedBy: 'foaf:fundedBy'
+          funding: 'schema:funding'
+          generalizes: 'mod:generalizes'
+          group: 'mod:group'
+          Group: 'mod:Group'
+          hasDisjunctionsWith: 'mod:hasDisjunctionsWith'
+          hasDisparateModelling: 'mod:hasDisparateModelling'
+          hasEquivalencesWith: 'mod:hasEquivalencesWith'
+          hasEvaluation: 'mod:hasEvaluation'
+          hasFormat: 'dcterms:hasFormat'
+          hasPart: 'dcterms:hasPart'
+          hasPolicy: 'odrl:hasPolicy'
+          hasVersion: 'dcterms:hasVersion'
+          hiddenLabel: 'skos:hiddenLabel'
+          homepage: 'foaf:homepage'
+          identifier: 'dcterms:identifier'
+          Image: 'foaf:Image'
+          includedInDataCatalog: 'schema:includedInDataCatalog'
+          incompatibleWith: 'owl:incompatibleWith'
+          isFormatOf: 'dcterms:isFormatOf'
+          isPartOf: 'dcterms:isPartOf'
+          isReferencedBy: 'dcterms:isReferencedBy'
+          issued: 'dcterms:issued'
+          itemsPerPage: 'hydra:itemsPerPage'
+          keyword: 'dcat:keyword'
+          Kind: 'vcard:Kind'
+          knownUsage: 'mod:knownUsage'
+          landingPage: 'dcat:landingPage'
+          language: 'dcterms:language'
+          lastPage: 'hydra:last'
+          license: 'dcterms:license'
+          Literal: 'rdfs:Literal'
+          logo: 'foaf:logo'
+          mailing-list: 'doap:mailing-list'
+          member: 'hydra:member'
+          metrics: 'mod:metrics'
+          modified: 'dcterms:modified'
+          morePermissions: 'cc:morePermissions'
+          nextPage: 'hydra:next'
+          nickname: 'vcard:nickname'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          numberOfAgents: 'mod:numberOfAgents'
+          numberOfEndorsements: 'mod:numberOfEndorsements'
+          numberOfEvaluations: 'mod:numberOfEvaluations'
+          numberOfNotes: 'mod:numberOfNotes'
+          numberOfUsers: 'mod:numberOfUsers'
+          numberOfUsingProjects: 'mod:numberOfUsingProjects'
+          Ontology: 'owl:Ontology'
+          openSearchDescription: 'void:openSearchDescription'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          preferredNamespacePrefix: 'vann:preferredNamespacePrefix'
+          preferredNamespaceUri: 'vann:preferredNamespaceUri'
+          previousPage: 'hydra:previous'
+          primaryTopic: 'foaf:primaryTopic'
+          priorVersion: 'owl:priorVersion'
+          Project: 'foaf:Project'
+          propertyPartition: 'void:propertyPartition'
+          publisher: 'dcterms:publisher'
+          qualifiedAttribution: 'prov:qualifiedAttribution'
+          qualifiedRelation: 'dcat:qualifiedRelation'
+          relation: 'dcterms:relation'
+          reliesOn: 'mod:reliesOn'
+          repository: 'doap:repository'
+          Resource: 'rdfs:Resource'
+          rights: 'dcterms:rights'
+          rightsHolder: 'dcterms:rightsHolder'
+          rootResource: 'void:rootResource'
+          SemanticArtefact: 'mod:SemanticArtefact'
+          semanticArtefactRelation: 'mod:semanticArtefactRelation'
+          SemanticArtefactTask: 'mod:SemanticArtefactTask'
+          similar: 'mod:similar'
+          source: 'dcterms:source'
+          specializes: 'mod:specializes'
+          status: 'mod:status'
+          string: 'xsd:string'
+          subject: 'dcterms:subject'
+          Thing: 'owl:Thing'
+          title: 'dcterms:title'
+          toDoList: 'mod:toDoList'
+          totalItems: 'hydra:totalItems'
+          translationOfWork: 'schema:translationOfWork'
+          translator: 'schema:translator'
+          type: 'dcterms:type'
+          URI: 'mod:URI'
+          uriLookupEndpoint: 'void:uriLookupEndpoint'
+          uriRegexPattern: 'void:uriRegexPattern'
+          usedBy: 'mod:usedBy'
+          usedInProject: 'mod:usedInProject'
+          useGuidelines: 'cc:useGuidelines'
+          versionInfo: 'owl:versionInfo'
+          versionIRI: 'owl:versionIRI'
+          view: 'hydra:view'
+          Vtodo: 'ical:Vtodo'
+          wasGeneratedBy: 'prov:wasGeneratedBy'
+          wasInvalidatedBy: 'prov:wasInvalidatedBy'
+          workTranslation: 'schema:workTranslation'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/SemanticArtefact/SemanticArtefactID'
+            '@type': SemanticArtefact
+            accessRights: string
+            conformsTo: string
+            contactPoint:
+              '@id': 'https://example.org/vcardKind/vcardKindID'
+              '@type': Kind
+              fn: Corky Crystal
+              nickname: Corks
+            creator: string
+            description:
+              '@type': Literal
+              '@value': Lorem ipsum
+            hasPolicy:
+              '@id': 'https://example.org/Policy/PolicyID'
+              '@type': 'odrl:Policy'
+            identifier:
+              '@type': Literal
+              '@value': Lorem ipsum
+            isReferencedBy: string
+            issued: string
+            keyword: string
+            landingPage:
+              '@id': 'https://example.org/Document/DocumentID'
+              '@type': Document
+            language: string
+            license: string
+            modified:
+              '@type': Literal
+              '@value': Lorem ipsum
+            publisher: string
+            qualifiedAttribution:
+              '@id': 'https://example.org/Attribution/AttributionID'
+              '@type': Attribution
+            qualifiedRelation: string
+            relation: string
+            rights: string
+            subject: string
+            title:
+              '@type': Literal
+              '@value': Lorem ipsum
+            type: string
+            useGuidelines:
+              '@id': 'https://example.org/Resource/ResourceID'
+              '@type': Resource
+            morePermissions:
+              '@id': 'https://example.org/Resource/ResourceID'
+              '@type': Resource
+            primaryTopic:
+              '@id': 'https://example.org/Thing/ThingID'
+              '@type': Thing
+            abstract: string
+            accrualMethod: string
+            accrualPeriodicity: string
+            accrualPolicy: string
+            alternative:
+              '@type': Literal
+              '@value': Lorem ipsum
+            audience: string
+            bibliographicCitation:
+              '@type': Literal
+              '@value': Lorem ipsum
+            contributor: string
+            coverage: string
+            hasFormat: string
+            hasPart: string
+            hasVersion: string
+            isFormatOf: string
+            isPartOf: string
+            rightsHolder: string
+            source: string
+            bug-database: string
+            mailing-list: string
+            repository:
+              '@id': 'https://example.org/repository/repositoryID'
+              '@type': repository
+            depiction:
+              '@id': 'https://example.org/Image/ImageID'
+              '@type': Image
+            fundedBy:
+              '@id': 'https://example.org/Thing/ThingID'
+              '@type': Thing
+            homepage:
+              '@id': 'https://example.org/Document/DocumentID'
+              '@type': Document
+            logo:
+              '@id': 'https://example.org/Thing/ThingID'
+              '@type': Thing
+            acronym:
+              '@type': string
+              '@value': Lorem ipsum
+            analytics:
+              '@id': 'https://example.org/Analytics/AnalyticsID'
+              '@type': Analytics
+            comesFromTheSameDomain: string
+            competencyQuestion:
+              '@type': string
+              '@value': Lorem ipsum
+            designedForTask:
+              '@id': 'https://example.org/SemanticArtefactTask/SemanticArtefactTaskID'
+              '@type': SemanticArtefactTask
+            endorsedBy: string
+            generalizes: string
+            group:
+              '@id': 'https://example.org/Group/GroupID'
+              '@type': Group
+            hasDisjunctionsWith: string
+            hasDisparateModelling: string
+            hasEquivalencesWith: string
+            hasEvaluation:
+              '@id': 'https://example.org/Evaluation/EvaluationID'
+              '@type': Evaluation
+            knownUsage:
+              '@type': string
+              '@value': Lorem ipsum
+            metrics:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfAgents:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfEndorsements:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfEvaluations:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfNotes:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfUsers:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            numberOfUsingProjects:
+              '@type': nonNegativeInteger
+              '@value': 5436
+            reliesOn: string
+            semanticArtefactRelation: string
+            similar: string
+            specializes: string
+            status:
+              '@type': string
+              '@value': Lorem ipsum
+            toDoList:
+              '@id': 'https://example.org/Vtodo/VtodoID'
+              '@type': Vtodo
+            URI:
+              '@type': anyURI
+              '@value': 'https://example.org'
+            usedBy: string
+            usedInProject:
+              '@id': 'https://example.org/Project/ProjectID'
+              '@type': Project
+            backwardCompatibleWith:
+              '@id': 'https://example.org/Ontology/OntologyID'
+              '@type': Ontology
+            deprecated:
+              '@id': 'https://example.org/Resource/ResourceID'
+              '@type': Resource
+            incompatibleWith:
+              '@id': 'https://example.org/Ontology/OntologyID'
+              '@type': Ontology
+            priorVersion:
+              '@id': 'https://example.org/Ontology/OntologyID'
+              '@type': Ontology
+            versionInfo:
+              '@type': string
+              '@value': Lorem ipsum
+            versionIRI:
+              '@id': 'https://example.org/Ontology/OntologyID'
+              '@type': Ontology
+            curatedBy: string
+            createdWith: string
+            wasGeneratedBy:
+              '@id': 'https://example.org/Activity/ActivityID'
+              '@type': Activity
+            wasInvalidatedBy:
+              '@id': 'https://example.org/Activity/ActivityID'
+              '@type': Activity
+            comment:
+              '@type': Literal
+              '@value': Lorem ipsum
+            associatedMedia: string
+            award: string
+            'schema:comment': string
+            funding: string
+            includedInDataCatalog: string
+            translationOfWork: string
+            translator: string
+            workTranslation: string
+            hiddenLabel:
+              '@type': Literal
+              '@value': Lorem ipsum
+            changes: string
+            example: string
+            preferredNamespacePrefix: string
+            preferredNamespaceUri: string
+            openSearchDescription:
+              '@id': 'https://example.org/Document/DocumentID'
+              '@type': Document
+            classPartition:
+              '@id': 'https://example.org/voidDataset/voidDatasetID'
+              '@type': dataset
+            exampleResource:
+              '@id': 'https://example.org/Resource/ResourceID'
+              '@type': Resource
+            rootResource:
+              '@id': 'https://example.org/Resource/ResourceID'
+              '@type': Resource
+            propertyPartition:
+              '@id': 'https://example.org/voidDataset/voidDatasetID'
+              '@type': dataset
+            uriLookupEndpoint:
+              '@type': anyURI
+              '@value': 'https://example.org'
+            uriRegexPattern: string
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+    semanticArtefactCatalogRecord:
+      summary: Semantic Artefact Catalog Record
+      value:
+        '@context':
+          dcat: 'http://www.w3.org/ns/dcat#'
+          dcterms: 'http://purl.org/dc/terms/'
+          foaf: 'http://xmlns.com/foaf/0.1/'
+          mod: 'https://w3id.org/mod#'
+          odrl: 'http://www.w3.org/ns/odrl/2/'
+          pav: 'http://purl.org/pav/'
+          prov: 'http://www.w3.org/ns/prov#'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          vcard: 'http://www.w3.org/2006/vcard/ns#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          accessRights: 'dcterms:accessRights'
+          Attribution: 'prov:Attribution'
+          conformsTo: 'dcterms:conformsTo'
+          contactPoint: 'dcat:contactPoint'
+          created: 'dcterms:created'
+          creator: 'dcterms:creator'
+          curatedBy: 'pav:curatedBy'
+          curatedOn: 'pav:curatedOn'
+          date: 'xsd:date'
+          dateSubmitted: 'dcterms:dateSubmitted'
+          description: 'dcterms:description'
+          Document: 'foaf:Document'
+          fn: 'vcard:fn'
+          hasPolicy: 'odrl:hasPolicy'
+          homepage: 'foaf:homepage'
+          identifier: 'dcterms:identifier'
+          isReferencedBy: 'dcterms:isReferencedBy'
+          issued: 'dcterms:issued'
+          keyword: 'dcat:keyword'
+          Kind: 'vcard:Kind'
+          landingPage: 'dcat:landingPage'
+          language: 'dcterms:language'
+          license: 'dcterms:license'
+          Literal: 'rdfs:Literal'
+          modified: 'dcterms:modified'
+          nickname: 'vcard:nickname'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          Policy: 'odrl:Policy'
+          primaryTopic: 'foaf:primaryTopic'
+          publisher: 'dcterms:publisher'
+          qualifiedAttribution: 'prov:qualifiedAttribution'
+          qualifiedRelation: 'dcat:qualifiedRelation'
+          relation: 'dcterms:relation'
+          rights: 'dcterms:rights'
+          SemanticArtefactCatalogRecord: 'mod:SemanticArtefactCatalogRecord'
+          subject: 'dcterms:subject'
+          title: 'dcterms:title'
+          type: 'dcterms:type'
+        '@id': >-
+          https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID
+        '@type': SemanticArtefactCatalogRecord
+        conformsTo: string
+        description:
+          '@type': Literal
+          '@value': Lorem ipsum
+        issued:
+          '@type': Literal
+          '@value': Lorem ipsum
+        modified:
+          '@type': Literal
+          '@value': Lorem ipsum
+        title:
+          '@type': Literal
+          '@value': Lorem ipsum
+        primaryTopic:
+          accessRights: string
+          conformsTo: string
+          contactPoint:
+            '@id': 'https://example.org/vcardKind/vcardKindID'
+            '@type': Kind
+            fn: Corky Crystal
+            nickname: Corks
+          creator: string
+          description:
+            '@type': Literal
+            '@value': Lorem ipsum
+          hasPolicy:
+            '@id': 'https://example.org/Policy/PolicyID'
+            '@type': Policy
+          identifier:
+            '@type': Literal
+            '@value': Lorem ipsum
+          isReferencedBy: string
+          issued: string
+          keyword: string
+          landingPage:
+            '@id': 'https://example.org/Document/DocumentID'
+            '@type': Document
+          language: string
+          license: string
+          modified:
+            '@type': Literal
+            '@value': Lorem ipsum
+          publisher: string
+          qualifiedAttribution:
+            '@id': 'https://example.org/Attribution/AttributionID'
+            '@type': Attribution
+          qualifiedRelation: string
+          relation: string
+          rights: string
+          subject: string
+          title:
+            '@type': Literal
+            '@value': Lorem ipsum
+          type: string
+        dateSubmitted:
+          '@type': Literal
+          '@value': Lorem ipsum
+        homepage:
+          '@id': 'https://example.org/Document/DocumentID'
+          '@type': Document
+        created:
+          '@type': Literal
+          '@value': Lorem ipsum
+        curatedBy: string
+        curatedOn:
+          '@type': date
+
+    semanticArtefactCatalogRecords:
+      summary: Semantic Artefact Catalog Records
+      value:
+        '@context':
+          dcat: 'http://www.w3.org/ns/dcat#'
+          dcterms: 'http://purl.org/dc/terms/'
+          foaf: 'http://xmlns.com/foaf/0.1/'
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          mod: 'https://w3id.org/mod#'
+          odrl: 'http://www.w3.org/ns/odrl/2/'
+          pav: 'http://purl.org/pav/'
+          prov: 'http://www.w3.org/ns/prov#'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          vcard: 'http://www.w3.org/2006/vcard/ns#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          accessRights: 'dcterms:accessRights'
+          Attribution: 'prov:Attribution'
+          Collection: 'hydra:Collection'
+          conformsTo: 'dcterms:conformsTo'
+          contactPoint: 'dcat:contactPoint'
+          created: 'dcterms:created'
+          creator: 'dcterms:creator'
+          curatedBy: 'pav:curatedBy'
+          curatedOn: 'pav:curatedOn'
+          date: 'xsd:date'
+          dateSubmitted: 'dcterms:dateSubmitted'
+          description: 'dcterms:description'
+          Document: 'foaf:Document'
+          firstPage: 'hydra:first'
+          fn: 'vcard:fn'
+          hasPolicy: 'odrl:hasPolicy'
+          homepage: 'foaf:homepage'
+          identifier: 'dcterms:identifier'
+          isReferencedBy: 'dcterms:isReferencedBy'
+          issued: 'dcterms:issued'
+          itemsPerPage: 'hydra:itemsPerPage'
+          keyword: 'dcat:keyword'
+          Kind: 'vcard:Kind'
+          landingPage: 'dcat:landingPage'
+          language: 'dcterms:language'
+          lastPage: 'hydra:last'
+          license: 'dcterms:license'
+          Literal: 'rdfs:Literal'
+          member: 'hydra:member'
+          modified: 'dcterms:modified'
+          nextPage: 'hydra:next'
+          nickname: 'vcard:nickname'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          Policy: 'odrl:Policy'
+          previousPage: 'hydra:previous'
+          primaryTopic: 'foaf:primaryTopic'
+          publisher: 'dcterms:publisher'
+          qualifiedAttribution: 'prov:qualifiedAttribution'
+          qualifiedRelation: 'dcat:qualifiedRelation'
+          relation: 'dcterms:relation'
+          rights: 'dcterms:rights'
+          SemanticArtefactCatalogRecord: 'mod:SemanticArtefactCatalogRecord'
+          subject: 'dcterms:subject'
+          title: 'dcterms:title'
+          totalItems: 'hydra:totalItems'
+          type: 'dcterms:type'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': >-
+              https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID
+            '@type': SemanticArtefactCatalogRecord
+            conformsTo: string
+            description:
+              '@type': Literal
+              '@value': Lorem ipsum
+            issued:
+              '@type': Literal
+              '@value': Lorem ipsum
+            modified:
+              '@type': Literal
+              '@value': Lorem ipsum
+            title:
+              '@type': Literal
+              '@value': Lorem ipsum
+            primaryTopic:
+              accessRights: string
+              conformsTo: string
+              contactPoint:
+                '@id': 'https://example.org/vcardKind/vcardKindID'
+                '@type': Kind
+                fn: Corky Crystal
+                nickname: Corks
+              creator: string
+              description:
+                '@type': Literal
+                '@value': Lorem ipsum
+              hasPolicy:
+                '@id': 'https://example.org/Policy/PolicyID'
+                '@type': Policy
+              identifier:
+                '@type': Literal
+                '@value': Lorem ipsum
+              isReferencedBy: string
+              issued: string
+              keyword: string
+              landingPage:
+                '@id': 'https://example.org/Document/DocumentID'
+                '@type': Document
+              language: string
+              license: string
+              modified:
+                '@type': Literal
+                '@value': Lorem ipsum
+              publisher: string
+              qualifiedAttribution:
+                '@id': 'https://example.org/Attribution/AttributionID'
+                '@type': Attribution
+              qualifiedRelation: string
+              relation: string
+              rights: string
+              subject: string
+              title:
+                '@type': Literal
+                '@value': Lorem ipsum
+              type: string
+            dateSubmitted:
+              '@type': Literal
+              '@value': Lorem ipsum
+            homepage:
+              '@id': 'https://example.org/Document/DocumentID'
+              '@type': Document
+            created:
+              '@type': Literal
+              '@value': Lorem ipsum
+            curatedBy: string
+            curatedOn:
+              '@type': date
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+    skosCollections:
+      summary: Collections
+      value:
+        '@context':
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          Collection: 'hydra:Collection'
+          firstPage: 'hydra:first'
+          itemsPerPage: 'hydra:itemsPerPage'
+          lastPage: 'hydra:last'
+          member: 'hydra:member'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          prefLabel: 'skos:prefLabel'
+          previousPage: 'hydra:previous'
+          skosCollection: 'skos:Collection'
+          totalItems: 'hydra:totalItems'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/skosCollection/skosCollectionID1'
+            '@type': skosCollection
+            prefLabel: collection of cars
+          - '@id': 'https://example.org/skosCollection/skosCollectionID2'
+            '@type': skosCollection
+            prefLabel: collection of cats
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+    skosConcepts:
+      summary: Concepts
+      value:
+        '@context':
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          Collection: 'hydra:Collection'
+          Concept: 'skos:Concept'
+          firstPage: 'hydra:first'
+          itemsPerPage: 'hydra:itemsPerPage'
+          lastPage: 'hydra:last'
+          member: 'hydra:member'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          prefLabel: 'skos:prefLabel'
+          previousPage: 'hydra:previous'
+          totalItems: 'hydra:totalItems'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/skosConcept/skosConceptID1'
+            '@type': Concept
+            prefLabel: cars
+          - '@id': 'https://example.org/skosConcept/skosConceptID2'
+            '@type': Concept
+            prefLabel: cats
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+    skosSchemes:
+      summary: Schemes
+      value:
+        '@context':
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          skos: 'http://www.w3.org/2004/02/skos/core#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          Collection: 'hydra:Collection'
+          firstPage: 'hydra:first'
+          itemsPerPage: 'hydra:itemsPerPage'
+          lastPage: 'hydra:last'
+          member: 'hydra:member'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          prefLabel: 'skos:prefLabel'
+          previousPage: 'hydra:previous'
+          ConceptScheme: 'skos:ConceptScheme'
+          totalItems: 'hydra:totalItems'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/skosScheme/skosSchemeID1'
+            '@type': ConceptScheme
+            prefLabel: cars scheme
+          - '@id': 'https://example.org/skosScheme/skosSchemeID2'
+            '@type': ConceptScheme
+            prefLabel: cats scheme
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+    rdfsProperties:
+      summary: Properties
+      value:
+        '@context':
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          Collection: 'hydra:Collection'
+          firstPage: 'hydra:first'
+          itemsPerPage: 'hydra:itemsPerPage'
+          lastPage: 'hydra:last'
+          member: 'hydra:member'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          Property: 'rdfs:Property'
+          previousPage: 'hydra:previous'
+          totalItems: 'hydra:totalItems'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/rdfsProperty/rdfsPropertyID'
+            '@type': Property
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
+
+    rdfsResource:
+      summary: Resource
+      value:
+        '@context':
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          Resource: 'rdfs:Resource'
+        '@id': 'https://example.org/Resource/ResourceID'
+        '@type': Resource
+
+    rdfsResources:
+      summary: Resources
+      value:
+        '@context':
+          hydra: 'http://www.w3.org/ns/hydra/core#'
+          rdfs: 'http://www.w3.org/2000/01/rdf-schema#'
+          xsd: 'http://www.w3.org/2001/XMLSchema#'
+          Collection: 'hydra:Collection'
+          firstPage: 'hydra:first'
+          itemsPerPage: 'hydra:itemsPerPage'
+          lastPage: 'hydra:last'
+          member: 'hydra:member'
+          nextPage: 'hydra:next'
+          nonNegativeInteger: 'xsd:nonNegativeInteger'
+          PartialCollectionView: 'hydra:PartialCollectionView'
+          previousPage: 'hydra:previous'
+          Resource: 'rdfs:Resource'
+          totalItems: 'hydra:totalItems'
+          view: 'hydra:view'
+        '@id': 'https://example.org/collection/collectionID'
+        '@type': Collection
+        totalItems:
+          '@type': nonNegativeInteger
+          '@value': 5436
+        itemsPerPage:
+          '@type': nonNegativeInteger
+          '@value': 50
+        member:
+          - '@id': 'https://example.org/Resource/ResourceID'
+            '@type': Resource
+        view:
+          '@id': 'https://example.org/items?page=3'
+          '@type': PartialCollectionView
+          firstPage: 'https://example.org/items?page=1'
+          previousPage: 'https://example.org/items?page=2'
+          nextPage: 'https://example.org/items?page=4'
+          lastPage: 'https://example.org/items?page=42'
 
   schemas:
     error_message:
@@ -2381,6 +3843,8 @@ components:
       description: rdf:Property is the class of RDF properties. rdf:Property is an instance of rdfs:Class.
       type: object
       properties:
+        '@id':
+          example: https://example.org/rdfsProperty/rdfsPropertyID
         '@type':
           example: rdfs:Property
 
@@ -2398,6 +3862,8 @@ components:
       title: Collection
       type: object
       properties:
+        '@id':
+          example: https://example.org/skosCollection/skosCollectionID
         '@type':
           example: skos:Collection
         skos:prefLabel:
@@ -2407,6 +3873,8 @@ components:
       title: Concept
       type: object
       properties:
+        '@id':
+          example: https://example.org/skosConcept/skosConceptID
         '@type':
           example: skos:Concept
         skos:prefLabel:
@@ -2416,6 +3884,8 @@ components:
       title: ConceptScheme
       type: object
       properties:
+        '@id':
+          example: https://example.org/skosScheme/skosSchemeID
         '@type':
           example: skos:ConceptScheme
         skos:prefLabel:

--- a/mod_api/static/mod_api/ttl/artefact.ttl
+++ b/mod_api/static/mod_api/ttl/artefact.ttl
@@ -49,7 +49,6 @@
   dc:rights "string"^^xsd:string ;
   dc:rightsHolder "string"^^xsd:string ;
   dc:source "string"^^xsd:string ;
-  dc:subject "string"^^xsd:string ;
   dc:title "Lorem ipsum"^^rdfs:Literal ;
   dc:type "string"^^xsd:string ;
   ns0:createdWith "string"^^xsd:string ;
@@ -75,7 +74,8 @@
   dcat:contactPoint <https://example.org/vcardKind/vcardKindID> ;
   dcat:keyword "string"^^xsd:string ;
   dcat:landingPage <https://example.org/Document/DocumentID> ;
-  dcat:qualifiedRelation "string"^^xsd:string ;
+  dcat:qualifiedRelation <https://example.org/Relationship/RelationshipID> ;
+  dcat:theme <https://example.org/Theme/ThemeID> ;
   odrl:hasPolicy <https://example.org/Policy/PolicyID> ;
   prov:qualifiedAttribution <https://example.org/Attribution/AttributionID> ;
   prov:wasGeneratedBy <https://example.org/Activity/ActivityID> ;
@@ -137,6 +137,8 @@
   vcard:fn "Corky Crystal"^^xsd:string ;
   vcard:nickname "Corks"^^xsd:string .
 
+<https://example.org/Relationship/RelationshipID> a dcat:Relationship .
+<https://example.org/Theme/ThemeID> a rdfs:Resource .
 <https://example.org/Policy/PolicyID> a odrl:Policy .
 <https://example.org/Attribution/AttributionID> a prov:Attribution .
 <https://example.org/Activity/ActivityID> a prov:Activity .

--- a/mod_api/static/mod_api/ttl/artefact.ttl
+++ b/mod_api/static/mod_api/ttl/artefact.ttl
@@ -1,0 +1,150 @@
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns0: <http://purl.org/pav/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ns1: <https://schema.org/> .
+@prefix ns2: <https://vocab.org/vann/> .
+@prefix ns3: <https://w3id.org/mod#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+<https://example.org/SemanticArtefact/SemanticArtefactID>
+  a <https://w3id.org/mod#SemanticArtefact> ;
+  cc:morePermissions <https://example.org/Resource/ResourceID> ;
+  cc:useGuidelines <https://example.org/Resource/ResourceID> ;
+  dc:abstract "string"^^xsd:string ;
+  dc:accessRights "string"^^xsd:string ;
+  dc:accrualMethod "string"^^xsd:string ;
+  dc:accrualPeriodicity "string"^^xsd:string ;
+  dc:accrualPolicy "string"^^xsd:string ;
+  dc:alternative "Lorem ipsum"^^rdfs:Literal ;
+  dc:audience "string"^^xsd:string ;
+  dc:bibliographicCitation "Lorem ipsum"^^rdfs:Literal ;
+  dc:conformsTo "string"^^xsd:string ;
+  dc:contributor "string"^^xsd:string ;
+  dc:coverage "string"^^xsd:string ;
+  dc:creator "string"^^xsd:string ;
+  dc:description "Lorem ipsum"^^rdfs:Literal ;
+  dc:hasFormat "string"^^xsd:string ;
+  dc:hasPart "string"^^xsd:string ;
+  dc:hasVersion "string"^^xsd:string ;
+  dc:identifier "Lorem ipsum"^^rdfs:Literal ;
+  dc:isFormatOf "string"^^xsd:string ;
+  dc:isPartOf "string"^^xsd:string ;
+  dc:isReferencedBy "string"^^xsd:string ;
+  dc:issued "string"^^xsd:string ;
+  dc:language "string"^^xsd:string ;
+  dc:license "string"^^xsd:string ;
+  dc:modified "Lorem ipsum"^^rdfs:Literal ;
+  dc:publisher "string"^^xsd:string ;
+  dc:relation "string"^^xsd:string ;
+  dc:rights "string"^^xsd:string ;
+  dc:rightsHolder "string"^^xsd:string ;
+  dc:source "string"^^xsd:string ;
+  dc:subject "string"^^xsd:string ;
+  dc:title "Lorem ipsum"^^rdfs:Literal ;
+  dc:type "string"^^xsd:string ;
+  ns0:createdWith "string"^^xsd:string ;
+  ns0:curatedBy "string"^^xsd:string ;
+  void:classPartition <https://example.org/voidDataset/voidDatasetID> ;
+  void:exampleResource <https://example.org/Resource/ResourceID> ;
+  void:openSearchDescription <https://example.org/Document/DocumentID> ;
+  void:propertyPartition <https://example.org/voidDataset/voidDatasetID> ;
+  void:rootResource <https://example.org/Resource/ResourceID> ;
+  void:uriLookupEndpoint "https://example.org"^^xsd:anyURI ;
+  void:uriRegexPattern "string"^^xsd:string ;
+  doap:bug-database "string"^^xsd:string ;
+  doap:mailing-list "string"^^xsd:string ;
+  doap:repository <https://example.org/repository/repositoryID> ;
+  rdfs:comment "Lorem ipsum"^^rdfs:Literal ;
+  owl:backwardCompatibleWith <https://example.org/Ontology/OntologyID> ;
+  owl:deprecated <https://example.org/Resource/ResourceID> ;
+  owl:incompatibleWith <https://example.org/Ontology/OntologyID> ;
+  owl:priorVersion <https://example.org/Ontology/OntologyID> ;
+  owl:versionIRI <https://example.org/Ontology/OntologyID> ;
+  owl:versionInfo "Lorem ipsum"^^xsd:string ;
+  skos:hiddenLabel "Lorem ipsum"^^rdfs:Literal ;
+  dcat:contactPoint <https://example.org/vcardKind/vcardKindID> ;
+  dcat:keyword "string"^^xsd:string ;
+  dcat:landingPage <https://example.org/Document/DocumentID> ;
+  dcat:qualifiedRelation "string"^^xsd:string ;
+  odrl:hasPolicy <https://example.org/Policy/PolicyID> ;
+  prov:qualifiedAttribution <https://example.org/Attribution/AttributionID> ;
+  prov:wasGeneratedBy <https://example.org/Activity/ActivityID> ;
+  prov:wasInvalidatedBy <https://example.org/Activity/ActivityID> ;
+  foaf:depiction <https://example.org/Image/ImageID> ;
+  foaf:fundedBy <https://example.org/Thing/ThingID> ;
+  foaf:homepage <https://example.org/Document/DocumentID> ;
+  foaf:logo <https://example.org/Thing/ThingID> ;
+  foaf:primaryTopic <https://example.org/Thing/ThingID> ;
+  ns1:associatedMedia "string"^^xsd:string ;
+  ns1:award "string"^^xsd:string ;
+  ns1:comment "string"^^xsd:string ;
+  ns1:funding "string"^^xsd:string ;
+  ns1:includedInDataCatalog "string"^^xsd:string ;
+  ns1:translationOfWork "string"^^xsd:string ;
+  ns1:translator "string"^^xsd:string ;
+  ns1:workTranslation "string"^^xsd:string ;
+  ns2:changes "string"^^xsd:string ;
+  ns2:example "string"^^xsd:string ;
+  ns2:preferredNamespacePrefix "string"^^xsd:string ;
+  ns2:preferredNamespaceUri "string"^^xsd:string ;
+  ns3:URI "https://example.org"^^xsd:anyURI ;
+  ns3:acronym "Lorem ipsum"^^xsd:string ;
+  ns3:analytics <https://example.org/Analytics/AnalyticsID> ;
+  ns3:comesFromTheSameDomain "string"^^xsd:string ;
+  ns3:competencyQuestion "Lorem ipsum"^^xsd:string ;
+  ns3:designedForTask <https://example.org/SemanticArtefactTask/SemanticArtefactTaskID> ;
+  ns3:endorsedBy "string"^^xsd:string ;
+  ns3:generalizes "string"^^xsd:string ;
+  ns3:group <https://example.org/Group/GroupID> ;
+  ns3:hasDisjunctionsWith "string"^^xsd:string ;
+  ns3:hasDisparateModelling "string"^^xsd:string ;
+  ns3:hasEquivalencesWith "string"^^xsd:string ;
+  ns3:hasEvaluation <https://example.org/Evaluation/EvaluationID> ;
+  ns3:knownUsage "Lorem ipsum"^^xsd:string ;
+  ns3:metrics "5436"^^xsd:nonNegativeInteger ;
+  ns3:numberOfAgents "5436"^^xsd:nonNegativeInteger ;
+  ns3:numberOfEndorsements "5436"^^xsd:nonNegativeInteger ;
+  ns3:numberOfEvaluations "5436"^^xsd:nonNegativeInteger ;
+  ns3:numberOfNotes "5436"^^xsd:nonNegativeInteger ;
+  ns3:numberOfUsers "5436"^^xsd:nonNegativeInteger ;
+  ns3:numberOfUsingProjects "5436"^^xsd:nonNegativeInteger ;
+  ns3:reliesOn "string"^^xsd:string ;
+  ns3:semanticArtefactRelation "string"^^xsd:string ;
+  ns3:similar "string"^^xsd:string ;
+  ns3:specializes "string"^^xsd:string ;
+  ns3:status "Lorem ipsum"^^xsd:string ;
+  ns3:toDoList <https://example.org/Vtodo/VtodoID> ;
+  ns3:usedBy "string"^^xsd:string ;
+  ns3:usedInProject <https://example.org/Project/ProjectID> .
+
+<https://example.org/Resource/ResourceID> a rdfs:Resource .
+<https://example.org/voidDataset/voidDatasetID> a void:dataset .
+<https://example.org/Document/DocumentID> a foaf:Document .
+<https://example.org/repository/repositoryID> a doap:repository .
+<https://example.org/Ontology/OntologyID> a owl:Ontology .
+<https://example.org/vcardKind/vcardKindID>
+  a vcard:Kind ;
+  vcard:fn "Corky Crystal"^^xsd:string ;
+  vcard:nickname "Corks"^^xsd:string .
+
+<https://example.org/Policy/PolicyID> a odrl:Policy .
+<https://example.org/Attribution/AttributionID> a prov:Attribution .
+<https://example.org/Activity/ActivityID> a prov:Activity .
+<https://example.org/Image/ImageID> a foaf:Image .
+<https://example.org/Thing/ThingID> a owl:Thing .
+<https://example.org/Analytics/AnalyticsID> a ns3:Analytics .
+<https://example.org/SemanticArtefactTask/SemanticArtefactTaskID> a ns3:SemanticArtefactTask .
+<https://example.org/Group/GroupID> a ns3:Group .
+<https://example.org/Evaluation/EvaluationID> a ns3:Evaluation .
+<https://example.org/Vtodo/VtodoID> a <http://www.w3.org/2002/12/cal/ical#Vtodo> .
+<https://example.org/Project/ProjectID> a foaf:Project .

--- a/mod_api/static/mod_api/ttl/artefacts.ttl
+++ b/mod_api/static/mod_api/ttl/artefacts.ttl
@@ -1,0 +1,164 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns1: <http://purl.org/pav/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix doap: <http://usefulinc.com/ns/doap#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ns2: <https://schema.org/> .
+@prefix ns3: <https://vocab.org/vann/> .
+@prefix ns4: <https://w3id.org/mod#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/SemanticArtefact/SemanticArtefactID> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/SemanticArtefact/SemanticArtefactID>
+  a <https://w3id.org/mod#SemanticArtefact> ;
+  cc:morePermissions <https://example.org/Resource/ResourceID> ;
+  cc:useGuidelines <https://example.org/Resource/ResourceID> ;
+  dc:abstract "string"^^xsd:string ;
+  dc:accessRights "string"^^xsd:string ;
+  dc:accrualMethod "string"^^xsd:string ;
+  dc:accrualPeriodicity "string"^^xsd:string ;
+  dc:accrualPolicy "string"^^xsd:string ;
+  dc:alternative "Lorem ipsum"^^rdfs:Literal ;
+  dc:audience "string"^^xsd:string ;
+  dc:bibliographicCitation "Lorem ipsum"^^rdfs:Literal ;
+  dc:conformsTo "string"^^xsd:string ;
+  dc:contributor "string"^^xsd:string ;
+  dc:coverage "string"^^xsd:string ;
+  dc:creator "string"^^xsd:string ;
+  dc:description "Lorem ipsum"^^rdfs:Literal ;
+  dc:hasFormat "string"^^xsd:string ;
+  dc:hasPart "string"^^xsd:string ;
+  dc:hasVersion "string"^^xsd:string ;
+  dc:identifier "Lorem ipsum"^^rdfs:Literal ;
+  dc:isFormatOf "string"^^xsd:string ;
+  dc:isPartOf "string"^^xsd:string ;
+  dc:isReferencedBy "string"^^xsd:string ;
+  dc:issued "string"^^xsd:string ;
+  dc:language "string"^^xsd:string ;
+  dc:license "string"^^xsd:string ;
+  dc:modified "Lorem ipsum"^^rdfs:Literal ;
+  dc:publisher "string"^^xsd:string ;
+  dc:relation "string"^^xsd:string ;
+  dc:rights "string"^^xsd:string ;
+  dc:rightsHolder "string"^^xsd:string ;
+  dc:source "string"^^xsd:string ;
+  dc:subject "string"^^xsd:string ;
+  dc:title "Lorem ipsum"^^rdfs:Literal ;
+  dc:type "string"^^xsd:string ;
+  ns1:createdWith "string"^^xsd:string ;
+  ns1:curatedBy "string"^^xsd:string ;
+  void:classPartition <https://example.org/voidDataset/voidDatasetID> ;
+  void:exampleResource <https://example.org/Resource/ResourceID> ;
+  void:openSearchDescription <https://example.org/Document/DocumentID> ;
+  void:propertyPartition <https://example.org/voidDataset/voidDatasetID> ;
+  void:rootResource <https://example.org/Resource/ResourceID> ;
+  void:uriLookupEndpoint "https://example.org"^^xsd:anyURI ;
+  void:uriRegexPattern "string"^^xsd:string ;
+  doap:bug-database "string"^^xsd:string ;
+  doap:mailing-list "string"^^xsd:string ;
+  doap:repository <https://example.org/repository/repositoryID> ;
+  rdfs:comment "Lorem ipsum"^^rdfs:Literal ;
+  owl:backwardCompatibleWith <https://example.org/Ontology/OntologyID> ;
+  owl:deprecated <https://example.org/Resource/ResourceID> ;
+  owl:incompatibleWith <https://example.org/Ontology/OntologyID> ;
+  owl:priorVersion <https://example.org/Ontology/OntologyID> ;
+  owl:versionIRI <https://example.org/Ontology/OntologyID> ;
+  owl:versionInfo "Lorem ipsum"^^xsd:string ;
+  skos:hiddenLabel "Lorem ipsum"^^rdfs:Literal ;
+  dcat:contactPoint <https://example.org/vcardKind/vcardKindID> ;
+  dcat:keyword "string"^^xsd:string ;
+  dcat:landingPage <https://example.org/Document/DocumentID> ;
+  dcat:qualifiedRelation "string"^^xsd:string ;
+  odrl:hasPolicy <https://example.org/Policy/PolicyID> ;
+  prov:qualifiedAttribution <https://example.org/Attribution/AttributionID> ;
+  prov:wasGeneratedBy <https://example.org/Activity/ActivityID> ;
+  prov:wasInvalidatedBy <https://example.org/Activity/ActivityID> ;
+  foaf:depiction <https://example.org/Image/ImageID> ;
+  foaf:fundedBy <https://example.org/Thing/ThingID> ;
+  foaf:homepage <https://example.org/Document/DocumentID> ;
+  foaf:logo <https://example.org/Thing/ThingID> ;
+  foaf:primaryTopic <https://example.org/Thing/ThingID> ;
+  ns2:associatedMedia "string"^^xsd:string ;
+  ns2:award "string"^^xsd:string ;
+  ns2:comment "string"^^xsd:string ;
+  ns2:funding "string"^^xsd:string ;
+  ns2:includedInDataCatalog "string"^^xsd:string ;
+  ns2:translationOfWork "string"^^xsd:string ;
+  ns2:translator "string"^^xsd:string ;
+  ns2:workTranslation "string"^^xsd:string ;
+  ns3:changes "string"^^xsd:string ;
+  ns3:example "string"^^xsd:string ;
+  ns3:preferredNamespacePrefix "string"^^xsd:string ;
+  ns3:preferredNamespaceUri "string"^^xsd:string ;
+  ns4:URI "https://example.org"^^xsd:anyURI ;
+  ns4:acronym "Lorem ipsum"^^xsd:string ;
+  ns4:analytics <https://example.org/Analytics/AnalyticsID> ;
+  ns4:comesFromTheSameDomain "string"^^xsd:string ;
+  ns4:competencyQuestion "Lorem ipsum"^^xsd:string ;
+  ns4:designedForTask <https://example.org/SemanticArtefactTask/SemanticArtefactTaskID> ;
+  ns4:endorsedBy "string"^^xsd:string ;
+  ns4:generalizes "string"^^xsd:string ;
+  ns4:group <https://example.org/Group/GroupID> ;
+  ns4:hasDisjunctionsWith "string"^^xsd:string ;
+  ns4:hasDisparateModelling "string"^^xsd:string ;
+  ns4:hasEquivalencesWith "string"^^xsd:string ;
+  ns4:hasEvaluation <https://example.org/Evaluation/EvaluationID> ;
+  ns4:knownUsage "Lorem ipsum"^^xsd:string ;
+  ns4:metrics "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfAgents "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfEndorsements "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfEvaluations "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfNotes "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfUsers "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfUsingProjects "5436"^^xsd:nonNegativeInteger ;
+  ns4:reliesOn "string"^^xsd:string ;
+  ns4:semanticArtefactRelation "string"^^xsd:string ;
+  ns4:similar "string"^^xsd:string ;
+  ns4:specializes "string"^^xsd:string ;
+  ns4:status "Lorem ipsum"^^xsd:string ;
+  ns4:toDoList <https://example.org/Vtodo/VtodoID> ;
+  ns4:usedBy "string"^^xsd:string ;
+  ns4:usedInProject <https://example.org/Project/ProjectID> .
+
+<https://example.org/Resource/ResourceID> a rdfs:Resource .
+<https://example.org/voidDataset/voidDatasetID> a void:dataset .
+<https://example.org/Document/DocumentID> a foaf:Document .
+<https://example.org/repository/repositoryID> a doap:repository .
+<https://example.org/Ontology/OntologyID> a owl:Ontology .
+<https://example.org/vcardKind/vcardKindID>
+  a vcard:Kind ;
+  vcard:fn "Corky Crystal"^^xsd:string ;
+  vcard:nickname "Corks"^^xsd:string .
+
+<https://example.org/Policy/PolicyID> a odrl:Policy .
+<https://example.org/Attribution/AttributionID> a prov:Attribution .
+<https://example.org/Activity/ActivityID> a prov:Activity .
+<https://example.org/Image/ImageID> a foaf:Image .
+<https://example.org/Thing/ThingID> a owl:Thing .
+<https://example.org/Analytics/AnalyticsID> a ns4:Analytics .
+<https://example.org/SemanticArtefactTask/SemanticArtefactTaskID> a ns4:SemanticArtefactTask .
+<https://example.org/Group/GroupID> a ns4:Group .
+<https://example.org/Evaluation/EvaluationID> a ns4:Evaluation .
+<https://example.org/Vtodo/VtodoID> a <http://www.w3.org/2002/12/cal/ical#Vtodo> .
+<https://example.org/Project/ProjectID> a foaf:Project .
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/catalog.ttl
+++ b/mod_api/static/mod_api/ttl/catalog.ttl
@@ -1,33 +1,27 @@
-@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix cc: <http://creativecommons.org/ns#> .
 @prefix dc: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix ns1: <http://purl.org/pav/> .
+@prefix ns0: <http://purl.org/pav/> .
 @prefix void: <http://rdfs.org/ns/void#> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ns1: <http://www.w3.org/ns/adms#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix ns2: <https://schema.org/> .
 @prefix ns3: <https://vocab.org/vann/> .
 @prefix ns4: <https://w3id.org/mod#> .
 @prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 
-<https://example.org/collection/collectionID>
-  a <http://www.w3.org/ns/hydra/core#Collection> ;
-  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
-  ns0:member <https://example.org/SemanticArtefact/SemanticArtefactID> ;
-  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
-  ns0:view <https://example.org/items?page=3> .
-
-<https://example.org/SemanticArtefact/SemanticArtefactID>
-  a <https://w3id.org/mod#SemanticArtefact> ;
-  cc:morePermissions <https://example.org/Resource/ResourceID> ;
-  cc:useGuidelines <https://example.org/Resource/ResourceID> ;
+<https://example.org/SemanticArtefactCatalog/SemanticArtefactCatalogID>
+  a <https://w3id.org/mod#SemanticArtefactCatalog> ;
+  cc:morePermissions <https://example.org/Resource/MorePermissionsResourceID> ;
+  cc:useGuidelines <https://example.org/Resource/UseGuidelinesResourceID> ;
   dc:abstract "string"^^xsd:string ;
   dc:accessRights "string"^^xsd:string ;
   dc:accrualMethod "string"^^xsd:string ;
@@ -39,13 +33,11 @@
   dc:conformsTo "string"^^xsd:string ;
   dc:contributor "string"^^xsd:string ;
   dc:coverage "string"^^xsd:string ;
+  dc:created "Lorem ipsum"^^rdfs:Literal ;
   dc:creator "string"^^xsd:string ;
   dc:description "Lorem ipsum"^^rdfs:Literal ;
-  dc:hasFormat "string"^^xsd:string ;
-  dc:hasPart "string"^^xsd:string ;
-  dc:hasVersion "string"^^xsd:string ;
+  dc:hasPart <https://example.org/Resource/ResourceID> ;
   dc:identifier "Lorem ipsum"^^rdfs:Literal ;
-  dc:isFormatOf "string"^^xsd:string ;
   dc:isPartOf "string"^^xsd:string ;
   dc:isReferencedBy "string"^^xsd:string ;
   dc:issued "string"^^xsd:string ;
@@ -57,110 +49,108 @@
   dc:rights "string"^^xsd:string ;
   dc:rightsHolder "string"^^xsd:string ;
   dc:source "string"^^xsd:string ;
+  dc:spatial "string"^^xsd:string ;
+  dc:temporal "string"^^xsd:string ;
   dc:title "Lorem ipsum"^^rdfs:Literal ;
   dc:type "string"^^xsd:string ;
-  ns1:createdWith "string"^^xsd:string ;
-  ns1:curatedBy "string"^^xsd:string ;
-  void:classPartition <https://example.org/voidDataset/voidDatasetID> ;
-  void:exampleResource <https://example.org/Resource/ResourceID> ;
+  ns0:createdWith "string"^^xsd:string ;
+  ns0:curatedBy "string"^^xsd:string ;
+  ns0:curatedOn [ a xsd:date ] ;
   void:openSearchDescription <https://example.org/Document/DocumentID> ;
-  void:propertyPartition <https://example.org/voidDataset/voidDatasetID> ;
-  void:rootResource <https://example.org/Resource/ResourceID> ;
-  void:uriLookupEndpoint "https://example.org"^^xsd:anyURI ;
+  void:uriLookupEndpoint "https://example.org/uriLookupEndpoint"^^xsd:anyURI ;
   void:uriRegexPattern "string"^^xsd:string ;
   doap:bug-database "string"^^xsd:string ;
   doap:mailing-list "string"^^xsd:string ;
   doap:repository <https://example.org/repository/repositoryID> ;
   rdfs:comment "Lorem ipsum"^^rdfs:Literal ;
-  owl:backwardCompatibleWith <https://example.org/Ontology/OntologyID> ;
-  owl:deprecated <https://example.org/Resource/ResourceID> ;
-  owl:incompatibleWith <https://example.org/Ontology/OntologyID> ;
-  owl:priorVersion <https://example.org/Ontology/OntologyID> ;
-  owl:versionIRI <https://example.org/Ontology/OntologyID> ;
+  owl:deprecated <https://example.org/Resource/DeprecatedResourceID> ;
   owl:versionInfo "Lorem ipsum"^^xsd:string ;
   skos:hiddenLabel "Lorem ipsum"^^rdfs:Literal ;
+  ns1:supportedSchema <https://example.org/asset/assetId> ;
+  dcat:accessURL <https://example.org/Resource/AccessURLResourceID> ;
+  dcat:catalog <https://example.org/Catalog/CatalogID> ;
   dcat:contactPoint <https://example.org/vcardKind/vcardKindID> ;
+  dcat:dataset <https://example.org/Dataset/DatasetID> ;
+  dcat:distribution <https://example.org/Distribution/DistributionID> ;
   dcat:keyword "string"^^xsd:string ;
   dcat:landingPage <https://example.org/Document/DocumentID> ;
   dcat:qualifiedRelation <https://example.org/Relationship/RelationshipID> ;
+  dcat:record <https://example.org/CatalogRecord/CatalogRecordID> ;
+  dcat:service <https://example.org/DataService/DataServiceID> ;
+  dcat:spatialResolutionInMeters "string"^^xsd:string ;
+  dcat:temporalResolution "string"^^xsd:string ;
   dcat:theme <https://example.org/Theme/ThemeID> ;
+  dcat:themeTaxonomy <https://example.org/Resource/ThemeTaxonomyResourceID> ;
   odrl:hasPolicy <https://example.org/Policy/PolicyID> ;
   prov:qualifiedAttribution <https://example.org/Attribution/AttributionID> ;
   prov:wasGeneratedBy <https://example.org/Activity/ActivityID> ;
-  prov:wasInvalidatedBy <https://example.org/Activity/ActivityID> ;
+  sd:endpoint "string"^^xsd:string ;
   foaf:depiction <https://example.org/Image/ImageID> ;
   foaf:fundedBy <https://example.org/Thing/ThingID> ;
   foaf:homepage <https://example.org/Document/DocumentID> ;
   foaf:logo <https://example.org/Thing/ThingID> ;
-  foaf:primaryTopic <https://example.org/Thing/ThingID> ;
   ns2:associatedMedia "string"^^xsd:string ;
   ns2:award "string"^^xsd:string ;
   ns2:comment "string"^^xsd:string ;
   ns2:funding "string"^^xsd:string ;
-  ns2:includedInDataCatalog "string"^^xsd:string ;
-  ns2:translationOfWork "string"^^xsd:string ;
+  ns2:publishingPrinciples "string"^^xsd:string ;
   ns2:translator "string"^^xsd:string ;
-  ns2:workTranslation "string"^^xsd:string ;
   ns3:changes "string"^^xsd:string ;
   ns3:example "string"^^xsd:string ;
   ns3:preferredNamespacePrefix "string"^^xsd:string ;
   ns3:preferredNamespaceUri "string"^^xsd:string ;
-  ns4:URI "https://example.org"^^xsd:anyURI ;
-  ns4:acronym "Lorem ipsum"^^xsd:string ;
   ns4:analytics <https://example.org/Analytics/AnalyticsID> ;
-  ns4:comesFromTheSameDomain "string"^^xsd:string ;
-  ns4:competencyQuestion "Lorem ipsum"^^xsd:string ;
-  ns4:designedForTask <https://example.org/SemanticArtefactTask/SemanticArtefactTaskID> ;
   ns4:endorsedBy "string"^^xsd:string ;
-  ns4:generalizes "string"^^xsd:string ;
+  ns4:fairScore "5436"^^xsd:nonNegativeInteger ;
   ns4:group <https://example.org/Group/GroupID> ;
-  ns4:hasDisjunctionsWith "string"^^xsd:string ;
-  ns4:hasDisparateModelling "string"^^xsd:string ;
-  ns4:hasEquivalencesWith "string"^^xsd:string ;
-  ns4:hasEvaluation <https://example.org/Evaluation/EvaluationID> ;
   ns4:knownUsage "Lorem ipsum"^^xsd:string ;
+  ns4:metadataVoc "https://example.org/metadataVoc"^^xsd:anyURI ;
   ns4:metrics "5436"^^xsd:nonNegativeInteger ;
   ns4:numberOfAgents "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfArtefacts "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfAxioms "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfClasses "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfDataProperties "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfDeprecated "5436"^^xsd:nonNegativeInteger ;
   ns4:numberOfEndorsements "5436"^^xsd:nonNegativeInteger ;
-  ns4:numberOfEvaluations "5436"^^xsd:nonNegativeInteger ;
-  ns4:numberOfNotes "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfIndividuals "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfLabels "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfMappings "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfObjectProperties "5436"^^xsd:nonNegativeInteger ;
+  ns4:numberOfProperties "5436"^^xsd:nonNegativeInteger ;
   ns4:numberOfUsers "5436"^^xsd:nonNegativeInteger ;
   ns4:numberOfUsingProjects "5436"^^xsd:nonNegativeInteger ;
-  ns4:reliesOn "string"^^xsd:string ;
-  ns4:semanticArtefactRelation "string"^^xsd:string ;
-  ns4:similar "string"^^xsd:string ;
-  ns4:specializes "string"^^xsd:string ;
   ns4:status "Lorem ipsum"^^xsd:string ;
   ns4:toDoList <https://example.org/Vtodo/VtodoID> ;
-  ns4:usedBy "string"^^xsd:string ;
   ns4:usedInProject <https://example.org/Project/ProjectID> .
 
-<https://example.org/Resource/ResourceID> a rdfs:Resource .
-<https://example.org/voidDataset/voidDatasetID> a void:dataset .
+<https://example.org/Resource/MorePermissionsResourceID> a rdfs:Resource .
+<https://example.org/Resource/UseGuidelinesResourceID> a rdfs:Resource .
+<https://example.org/Resource/ResourceID> a dcat:Resource .
 <https://example.org/Document/DocumentID> a foaf:Document .
 <https://example.org/repository/repositoryID> a doap:repository .
-<https://example.org/Ontology/OntologyID> a owl:Ontology .
+<https://example.org/Resource/DeprecatedResourceID> a rdfs:Resource .
+<https://example.org/asset/assetId> a ns1:Asset .
+<https://example.org/Resource/AccessURLResourceID> a rdfs:Resource .
+<https://example.org/Catalog/CatalogID> a dcat:Catalog .
 <https://example.org/vcardKind/vcardKindID>
   a vcard:Kind ;
   vcard:fn "Corky Crystal"^^xsd:string ;
   vcard:nickname "Corks"^^xsd:string .
 
+<https://example.org/Dataset/DatasetID> a dcat:Dataset .
+<https://example.org/Distribution/DistributionID> a dcat:Distribution .
 <https://example.org/Relationship/RelationshipID> a dcat:Relationship .
+<https://example.org/CatalogRecord/CatalogRecordID> a dcat:CatalogRecord .
+<https://example.org/DataService/DataServiceID> a dcat:DataService .
 <https://example.org/Theme/ThemeID> a rdfs:Resource .
+<https://example.org/Resource/ThemeTaxonomyResourceID> a rdfs:Resource .
 <https://example.org/Policy/PolicyID> a odrl:Policy .
 <https://example.org/Attribution/AttributionID> a prov:Attribution .
 <https://example.org/Activity/ActivityID> a prov:Activity .
 <https://example.org/Image/ImageID> a foaf:Image .
 <https://example.org/Thing/ThingID> a owl:Thing .
 <https://example.org/Analytics/AnalyticsID> a ns4:Analytics .
-<https://example.org/SemanticArtefactTask/SemanticArtefactTaskID> a ns4:SemanticArtefactTask .
 <https://example.org/Group/GroupID> a ns4:Group .
-<https://example.org/Evaluation/EvaluationID> a ns4:Evaluation .
 <https://example.org/Vtodo/VtodoID> a <http://www.w3.org/2002/12/cal/ical#Vtodo> .
 <https://example.org/Project/ProjectID> a foaf:Project .
-<https://example.org/items?page=3>
-  a ns0:PartialCollectionView ;
-  ns0:first "https://example.org/items?page=1"^^xsd:string ;
-  ns0:last "https://example.org/items?page=42"^^xsd:string ;
-  ns0:next "https://example.org/items?page=4"^^xsd:string ;
-  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/classes.ttl
+++ b/mod_api/static/mod_api/ttl/classes.ttl
@@ -1,0 +1,19 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/Class/ClassID1>, <https://example.org/Class/ClassID2> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/Class/ClassID1> a owl:Class .
+<https://example.org/Class/ClassID2> a owl:Class .
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/collections.ttl
+++ b/mod_api/static/mod_api/ttl/collections.ttl
@@ -1,0 +1,25 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/skosCollection/skosCollectionID1>, <https://example.org/skosCollection/skosCollectionID2> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/skosCollection/skosCollectionID1>
+  a skos:Collection ;
+  skos:prefLabel "collection of cars"^^xsd:string .
+
+<https://example.org/skosCollection/skosCollectionID2>
+  a skos:Collection ;
+  skos:prefLabel "collection of cats"^^xsd:string .
+
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/concepts.ttl
+++ b/mod_api/static/mod_api/ttl/concepts.ttl
@@ -1,0 +1,25 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/skosConcept/skosConceptID1>, <https://example.org/skosConcept/skosConceptID2> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/skosConcept/skosConceptID1>
+  a skos:Concept ;
+  skos:prefLabel "cars"^^xsd:string .
+
+<https://example.org/skosConcept/skosConceptID2>
+  a skos:Concept ;
+  skos:prefLabel "cats"^^xsd:string .
+
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/distribution.ttl
+++ b/mod_api/static/mod_api/ttl/distribution.ttl
@@ -1,0 +1,90 @@
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns0: <http://purl.org/pav/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix ns1: <https://w3id.org/mod#> .
+
+<https://example.org/SemanticArtefactDistribution/SemanticArtefactDistributionID>
+  a <https://w3id.org/mod#SemanticArtefactDistribution> ;
+  cc:useGuidelines <https://example.org/Resource/UseGuidelinesResourceID> ;
+  dc:accessRights "string"^^xsd:string ;
+  dc:conformsTo "string"^^xsd:string ;
+  dc:created "Lorem ipsum"^^rdfs:Literal ;
+  dc:dateSubmitted "Lorem ipsum"^^rdfs:Literal ;
+  dc:description "Lorem ipsum"^^rdfs:Literal ;
+  dc:format "string"^^xsd:string ;
+  dc:issued "Lorem ipsum"^^rdfs:Literal ;
+  dc:license "string"^^xsd:string ;
+  dc:modified "Lorem ipsum"^^rdfs:Literal ;
+  dc:rights "string"^^xsd:string ;
+  dc:title "Lorem ipsum"^^rdfs:Literal ;
+  dc:valid "Lorem ipsum"^^rdfs:Literal ;
+  ns0:curatedOn [ a xsd:date ] ;
+  owl:deprecated <https://example.org/Resource/DeprecatedResourceID> ;
+  owl:imports <https://example.org/Ontology/OntologyID> ;
+  dcat:accessService <https://example.org/DataService/DataServiceID> ;
+  dcat:accessURL <https://example.org/Resource/AccessURLResourceID> ;
+  dcat:byteSize "string"^^xsd:string ;
+  dcat:compressFormat "string"^^xsd:string ;
+  dcat:downloadURL <https://example.org/Resource/DownloadURLResourceID> ;
+  dcat:mediaType "string"^^xsd:string ;
+  dcat:packageFormat "string"^^xsd:string ;
+  dcat:spatialResolutionInMeters "string"^^xsd:string ;
+  dcat:temporalResolution "string"^^xsd:string ;
+  odrl:hasPolicy <https://example.org/Policy/PolicyID> ;
+  sd:endpoint "string"^^xsd:string ;
+  ns1:FairAssessment <https://example.org/FairAssessment/FairAssessmentID> ;
+  ns1:authorProperty "https://example.org/authorProperty"^^xsd:anyURI ;
+  ns1:averageChildCount 4.0 ;
+  ns1:browsingUI "https://example.org/browsingUI"^^xsd:anyURI ;
+  ns1:classesWithMoreThan25Children "5436"^^xsd:nonNegativeInteger ;
+  ns1:classesWithNoAuthorMetadata "5436"^^xsd:nonNegativeInteger ;
+  ns1:classesWithNoDateMetadata "5436"^^xsd:nonNegativeInteger ;
+  ns1:classesWithNoDefinition "5436"^^xsd:nonNegativeInteger ;
+  ns1:classesWithNoFormalDefinition "5436"^^xsd:nonNegativeInteger ;
+  ns1:classesWithNoLabel "5436"^^xsd:nonNegativeInteger ;
+  ns1:classesWithOneChild "5436"^^xsd:nonNegativeInteger ;
+  ns1:conformsToKnowledgeRepresentationParadigm <https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID> ;
+  ns1:createdProperty "https://example.org/createdProperty"^^xsd:anyURI ;
+  ns1:definitionProperty "https://example.org/definitionProperty"^^xsd:anyURI ;
+  ns1:fairScore "5436"^^xsd:nonNegativeInteger ;
+  ns1:hasFormalityLevel "Lorem ipsum"^^xsd:string ;
+  ns1:hasRepresentationLanguage "Lorem ipsum"^^xsd:string ;
+  ns1:hasSyntax "https://example.org/hasSyntax"^^xsd:anyURI ;
+  ns1:hierarchyProperty "https://example.org/hierarchyProperty"^^xsd:anyURI ;
+  ns1:maxChildCount "5436"^^xsd:nonNegativeInteger ;
+  ns1:maxDepth "5436"^^xsd:nonNegativeInteger ;
+  ns1:metadataVoc "https://example.org/metadataVoc"^^xsd:anyURI ;
+  ns1:metrics "5436"^^xsd:nonNegativeInteger ;
+  ns1:modifiedProperty "https://example.org/modifiedProperty"^^xsd:anyURI ;
+  ns1:numberOfAxioms "5436"^^xsd:nonNegativeInteger ;
+  ns1:numberOfClasses 0 ;
+  ns1:numberOfDataProperties "5436"^^xsd:nonNegativeInteger ;
+  ns1:numberOfDeprecated "5436"^^xsd:nonNegativeInteger ;
+  ns1:numberOfIndividuals "5436"^^xsd:nonNegativeInteger ;
+  ns1:numberOfLabels "5436"^^xsd:nonNegativeInteger ;
+  ns1:numberOfMappings "5436"^^xsd:nonNegativeInteger ;
+  ns1:numberOfObjectProperties "5436"^^xsd:nonNegativeInteger ;
+  ns1:numberOfProperties "5436"^^xsd:nonNegativeInteger ;
+  ns1:obsoleteParent "https://example.org/obsoleteParent"^^xsd:anyURI ;
+  ns1:obsoleteProperty "https://example.org/obsoleteProperty"^^xsd:anyURI ;
+  ns1:prefLabelProperty "https://example.org/prefLabelProperty"^^xsd:anyURI ;
+  ns1:sampleQueries "https://example.org/sampleQueries"^^xsd:anyURI ;
+  ns1:synonymProperty "https://example.org/synonymProperty"^^xsd:anyURI ;
+  ns1:usedEngineeringMethodology <https://example.org/EngineeringMethodology/EngineeringMethodologyID> .
+
+<https://example.org/Resource/UseGuidelinesResourceID> a rdfs:Resource .
+<https://example.org/Resource/DeprecatedResourceID> a rdfs:Resource .
+<https://example.org/Ontology/OntologyID> a owl:Ontology .
+<https://example.org/DataService/DataServiceID> a dcat:DataService .
+<https://example.org/Resource/AccessURLResourceID> a rdfs:Resource .
+<https://example.org/Resource/DownloadURLResourceID> a rdfs:Resource .
+<https://example.org/Policy/PolicyID> a odrl:Policy .
+<https://example.org/FairAssessment/FairAssessmentID> a <http://njh.me/FairAssessment> .
+<https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID> a ns1:KnowledgeRepresentationParadigm .
+<https://example.org/EngineeringMethodology/EngineeringMethodologyID> a ns1:EngineeringMethodology .

--- a/mod_api/static/mod_api/ttl/distribution.ttl
+++ b/mod_api/static/mod_api/ttl/distribution.ttl
@@ -63,7 +63,7 @@
   ns1:metrics "5436"^^xsd:nonNegativeInteger ;
   ns1:modifiedProperty "https://example.org/modifiedProperty"^^xsd:anyURI ;
   ns1:numberOfAxioms "5436"^^xsd:nonNegativeInteger ;
-  ns1:numberOfClasses 0 ;
+  ns1:numberOfClasses "5436"^^xsd:nonNegativeInteger ;
   ns1:numberOfDataProperties "5436"^^xsd:nonNegativeInteger ;
   ns1:numberOfDeprecated "5436"^^xsd:nonNegativeInteger ;
   ns1:numberOfIndividuals "5436"^^xsd:nonNegativeInteger ;

--- a/mod_api/static/mod_api/ttl/distributions.ttl
+++ b/mod_api/static/mod_api/ttl/distributions.ttl
@@ -1,0 +1,104 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix cc: <http://creativecommons.org/ns#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns1: <http://purl.org/pav/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix ns2: <https://w3id.org/mod#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/SemanticArtefactDistribution/SemanticArtefactDistributionID> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/SemanticArtefactDistribution/SemanticArtefactDistributionID>
+  a <https://w3id.org/mod#SemanticArtefactDistribution> ;
+  cc:useGuidelines <https://example.org/Resource/UseGuidelinesResourceID> ;
+  dc:accessRights "string"^^xsd:string ;
+  dc:conformsTo "string"^^xsd:string ;
+  dc:created "Lorem ipsum"^^rdfs:Literal ;
+  dc:dateSubmitted "Lorem ipsum"^^rdfs:Literal ;
+  dc:description "Lorem ipsum"^^rdfs:Literal ;
+  dc:format "string"^^xsd:string ;
+  dc:issued "Lorem ipsum"^^rdfs:Literal ;
+  dc:license "string"^^xsd:string ;
+  dc:modified "Lorem ipsum"^^rdfs:Literal ;
+  dc:rights "string"^^xsd:string ;
+  dc:title "Lorem ipsum"^^rdfs:Literal ;
+  dc:valid "Lorem ipsum"^^rdfs:Literal ;
+  ns1:curatedOn [ a xsd:date ] ;
+  owl:deprecated <https://example.org/Resource/DeprecatedResourceID> ;
+  owl:imports <https://example.org/Ontology/OntologyID> ;
+  dcat:accessService <https://example.org/DataService/DataServiceID> ;
+  dcat:accessURL <https://example.org/Resource/AccessURLResourceID> ;
+  dcat:byteSize "string"^^xsd:string ;
+  dcat:compressFormat "string"^^xsd:string ;
+  dcat:downloadURL <https://example.org/Resource/DownloadURLResourceID> ;
+  dcat:mediaType "string"^^xsd:string ;
+  dcat:packageFormat "string"^^xsd:string ;
+  dcat:spatialResolutionInMeters "string"^^xsd:string ;
+  dcat:temporalResolution "string"^^xsd:string ;
+  odrl:hasPolicy <https://example.org/Policy/PolicyID> ;
+  sd:endpoint "string"^^xsd:string ;
+  ns2:FairAssessment <https://example.org/FairAssessment/FairAssessmentID> ;
+  ns2:authorProperty "https://example.org/authorProperty"^^xsd:anyURI ;
+  ns2:averageChildCount 4.0 ;
+  ns2:browsingUI "https://example.org/browsingUI"^^xsd:anyURI ;
+  ns2:classesWithMoreThan25Children "5436"^^xsd:nonNegativeInteger ;
+  ns2:classesWithNoAuthorMetadata "5436"^^xsd:nonNegativeInteger ;
+  ns2:classesWithNoDateMetadata "5436"^^xsd:nonNegativeInteger ;
+  ns2:classesWithNoDefinition "5436"^^xsd:nonNegativeInteger ;
+  ns2:classesWithNoFormalDefinition "5436"^^xsd:nonNegativeInteger ;
+  ns2:classesWithNoLabel "5436"^^xsd:nonNegativeInteger ;
+  ns2:classesWithOneChild "5436"^^xsd:nonNegativeInteger ;
+  ns2:conformsToKnowledgeRepresentationParadigm <https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID> ;
+  ns2:createdProperty "https://example.org/createdProperty"^^xsd:anyURI ;
+  ns2:definitionProperty "https://example.org/definitionProperty"^^xsd:anyURI ;
+  ns2:fairScore "5436"^^xsd:nonNegativeInteger ;
+  ns2:hasFormalityLevel "Lorem ipsum"^^xsd:string ;
+  ns2:hasRepresentationLanguage "Lorem ipsum"^^xsd:string ;
+  ns2:hasSyntax "https://example.org/hasSyntax"^^xsd:anyURI ;
+  ns2:hierarchyProperty "https://example.org/hierarchyProperty"^^xsd:anyURI ;
+  ns2:maxChildCount "5436"^^xsd:nonNegativeInteger ;
+  ns2:maxDepth "5436"^^xsd:nonNegativeInteger ;
+  ns2:metadataVoc "https://example.org/metadataVoc"^^xsd:anyURI ;
+  ns2:metrics "5436"^^xsd:nonNegativeInteger ;
+  ns2:modifiedProperty "https://example.org/modifiedProperty"^^xsd:anyURI ;
+  ns2:numberOfAxioms "5436"^^xsd:nonNegativeInteger ;
+  ns2:numberOfClasses 0 ;
+  ns2:numberOfDataProperties "5436"^^xsd:nonNegativeInteger ;
+  ns2:numberOfDeprecated "5436"^^xsd:nonNegativeInteger ;
+  ns2:numberOfIndividuals "5436"^^xsd:nonNegativeInteger ;
+  ns2:numberOfLabels "5436"^^xsd:nonNegativeInteger ;
+  ns2:numberOfMappings "5436"^^xsd:nonNegativeInteger ;
+  ns2:numberOfObjectProperties "5436"^^xsd:nonNegativeInteger ;
+  ns2:numberOfProperties "5436"^^xsd:nonNegativeInteger ;
+  ns2:obsoleteParent "https://example.org/obsoleteParent"^^xsd:anyURI ;
+  ns2:obsoleteProperty "https://example.org/obsoleteProperty"^^xsd:anyURI ;
+  ns2:prefLabelProperty "https://example.org/prefLabelProperty"^^xsd:anyURI ;
+  ns2:sampleQueries "https://example.org/sampleQueries"^^xsd:anyURI ;
+  ns2:synonymProperty "https://example.org/synonymProperty"^^xsd:anyURI ;
+  ns2:usedEngineeringMethodology <https://example.org/EngineeringMethodology/EngineeringMethodologyID> .
+
+<https://example.org/Resource/UseGuidelinesResourceID> a rdfs:Resource .
+<https://example.org/Resource/DeprecatedResourceID> a rdfs:Resource .
+<https://example.org/Ontology/OntologyID> a owl:Ontology .
+<https://example.org/DataService/DataServiceID> a dcat:DataService .
+<https://example.org/Resource/AccessURLResourceID> a rdfs:Resource .
+<https://example.org/Resource/DownloadURLResourceID> a rdfs:Resource .
+<https://example.org/Policy/PolicyID> a odrl:Policy .
+<https://example.org/FairAssessment/FairAssessmentID> a <http://njh.me/FairAssessment> .
+<https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID> a ns2:KnowledgeRepresentationParadigm .
+<https://example.org/EngineeringMethodology/EngineeringMethodologyID> a ns2:EngineeringMethodology .
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/distributions.ttl
+++ b/mod_api/static/mod_api/ttl/distributions.ttl
@@ -71,7 +71,7 @@
   ns2:metrics "5436"^^xsd:nonNegativeInteger ;
   ns2:modifiedProperty "https://example.org/modifiedProperty"^^xsd:anyURI ;
   ns2:numberOfAxioms "5436"^^xsd:nonNegativeInteger ;
-  ns2:numberOfClasses 0 ;
+  ns2:numberOfClasses "5436"^^xsd:nonNegativeInteger ;
   ns2:numberOfDataProperties "5436"^^xsd:nonNegativeInteger ;
   ns2:numberOfDeprecated "5436"^^xsd:nonNegativeInteger ;
   ns2:numberOfIndividuals "5436"^^xsd:nonNegativeInteger ;

--- a/mod_api/static/mod_api/ttl/individuals.ttl
+++ b/mod_api/static/mod_api/ttl/individuals.ttl
@@ -1,0 +1,19 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/NamedIndividual/NamedIndividualID1>, <https://example.org/NamedIndividual/NamedIndividualID2> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/NamedIndividual/NamedIndividualID1> a owl:NamedIndividual .
+<https://example.org/NamedIndividual/NamedIndividualID2> a owl:NamedIndividual .
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/properties.ttl
+++ b/mod_api/static/mod_api/ttl/properties.ttl
@@ -1,0 +1,18 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/rdfsProperty/rdfsPropertyID> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/rdfsProperty/rdfsPropertyID> a rdfs:Property .
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/record.ttl
+++ b/mod_api/static/mod_api/ttl/record.ttl
@@ -1,0 +1,23 @@
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns0: <http://purl.org/pav/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+<https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID>
+  a <https://w3id.org/mod#SemanticArtefactCatalogRecord> ;
+  dc:conformsTo "string"^^xsd:string ;
+  dc:created "Lorem ipsum"^^rdfs:Literal ;
+  dc:dateSubmitted "Lorem ipsum"^^rdfs:Literal ;
+  dc:description "Lorem ipsum"^^rdfs:Literal ;
+  dc:issued "Lorem ipsum"^^rdfs:Literal ;
+  dc:modified "Lorem ipsum"^^rdfs:Literal ;
+  dc:title "Lorem ipsum"^^rdfs:Literal ;
+  ns0:curatedBy "string"^^xsd:string ;
+  ns0:curatedOn [ a xsd:date ] ;
+  foaf:homepage <https://example.org/Document/DocumentID> ;
+  foaf:primaryTopic <https://example.org/dcatResource/dcatResourceID> .
+
+<https://example.org/Document/DocumentID> a foaf:Document .
+<https://example.org/dcatResource/dcatResourceID> a dcat:Resource .

--- a/mod_api/static/mod_api/ttl/records.ttl
+++ b/mod_api/static/mod_api/ttl/records.ttl
@@ -1,0 +1,37 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ns1: <http://purl.org/pav/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID>
+  a <https://w3id.org/mod#SemanticArtefactCatalogRecord> ;
+  dc:conformsTo "string"^^xsd:string ;
+  dc:created "Lorem ipsum"^^rdfs:Literal ;
+  dc:dateSubmitted "Lorem ipsum"^^rdfs:Literal ;
+  dc:description "Lorem ipsum"^^rdfs:Literal ;
+  dc:issued "Lorem ipsum"^^rdfs:Literal ;
+  dc:modified "Lorem ipsum"^^rdfs:Literal ;
+  dc:title "Lorem ipsum"^^rdfs:Literal ;
+  ns1:curatedBy "string"^^xsd:string ;
+  ns1:curatedOn [ a xsd:date ] ;
+  foaf:homepage <https://example.org/Document/DocumentID> ;
+  foaf:primaryTopic <https://example.org/dcatResource/dcatResourceID> .
+
+<https://example.org/Document/DocumentID> a foaf:Document .
+<https://example.org/dcatResource/dcatResourceID> a dcat:Resource .
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/resource.ttl
+++ b/mod_api/static/mod_api/ttl/resource.ttl
@@ -1,0 +1,3 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://example.org/rdfsResource/rdfsResourceID> a rdfs:Resource .

--- a/mod_api/static/mod_api/ttl/resources.ttl
+++ b/mod_api/static/mod_api/ttl/resources.ttl
@@ -1,0 +1,18 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/rdfsResource/rdfsResourceID> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/rdfsResource/rdfsResourceID> a rdfs:Resource .
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/ttl/schemes.ttl
+++ b/mod_api/static/mod_api/ttl/schemes.ttl
@@ -1,0 +1,25 @@
+@prefix ns0: <http://www.w3.org/ns/hydra/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://example.org/collection/collectionID>
+  a <http://www.w3.org/ns/hydra/core#Collection> ;
+  ns0:itemsPerPage "50"^^xsd:nonNegativeInteger ;
+  ns0:member <https://example.org/skosScheme/skosSchemeID1>, <https://example.org/skosScheme/skosSchemeID2> ;
+  ns0:totalItems "5436"^^xsd:nonNegativeInteger ;
+  ns0:view <https://example.org/items?page=3> .
+
+<https://example.org/skosScheme/skosSchemeID1>
+  a skos:ConceptScheme ;
+  skos:prefLabel "cars scheme"^^xsd:string .
+
+<https://example.org/skosScheme/skosSchemeID2>
+  a skos:ConceptScheme ;
+  skos:prefLabel "cats scheme"^^xsd:string .
+
+<https://example.org/items?page=3>
+  a ns0:PartialCollectionView ;
+  ns0:first "https://example.org/items?page=1"^^xsd:string ;
+  ns0:last "https://example.org/items?page=42"^^xsd:string ;
+  ns0:next "https://example.org/items?page=4"^^xsd:string ;
+  ns0:previous "https://example.org/items?page=2"^^xsd:string .

--- a/mod_api/static/mod_api/xml/artefact.xml
+++ b/mod_api/static/mod_api/xml/artefact.xml
@@ -50,7 +50,6 @@
     <dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rights>
     <dc:rightsHolder rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rightsHolder>
     <dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:source>
-    <dc:subject rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:subject>
     <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
     <dc:type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:type>
     <ns0:createdWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns0:createdWith>
@@ -86,7 +85,16 @@
 
     <dcat:keyword rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:keyword>
     <dcat:landingPage rdf:resource="https://example.org/Document/DocumentID"/>
-    <dcat:qualifiedRelation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:qualifiedRelation>
+    <dcat:qualifiedRelation>
+      <dcat:Relationship rdf:about="https://example.org/Relationship/RelationshipID">
+      </dcat:Relationship>
+    </dcat:qualifiedRelation>
+
+    <dcat:theme>
+      <rdfs:Resource rdf:about="https://example.org/Theme/ThemeID">
+      </rdfs:Resource>
+    </dcat:theme>
+
     <odrl:hasPolicy>
       <odrl:Policy rdf:about="https://example.org/Policy/PolicyID">
       </odrl:Policy>

--- a/mod_api/static/mod_api/xml/artefact.xml
+++ b/mod_api/static/mod_api/xml/artefact.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:cc="http://creativecommons.org/ns#"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:ns0="http://purl.org/pav/"
+         xmlns:void="http://rdfs.org/ns/void#"
+         xmlns:doap="http://usefulinc.com/ns/doap#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+         xmlns:odrl="http://www.w3.org/ns/odrl/2/"
+         xmlns:prov="http://www.w3.org/ns/prov#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:ns1="https://schema.org/"
+         xmlns:ns2="https://vocab.org/vann/"
+         xmlns:ns3="https://w3id.org/mod#">
+
+  <rdf:Description rdf:about="https://example.org/SemanticArtefact/SemanticArtefactID">
+    <rdf:type rdf:resource="https://w3id.org/mod#SemanticArtefact"/>
+    <cc:morePermissions rdf:resource="https://example.org/Resource/ResourceID"/>
+    <cc:useGuidelines rdf:resource="https://example.org/Resource/ResourceID"/>
+    <dc:abstract rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:abstract>
+    <dc:accessRights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accessRights>
+    <dc:accrualMethod rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualMethod>
+    <dc:accrualPeriodicity rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualPeriodicity>
+    <dc:accrualPolicy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualPolicy>
+    <dc:alternative rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:alternative>
+    <dc:audience rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:audience>
+    <dc:bibliographicCitation rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:bibliographicCitation>
+    <dc:conformsTo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:conformsTo>
+    <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:contributor>
+    <dc:coverage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:coverage>
+    <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:creator>
+    <dc:description rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:description>
+    <dc:hasFormat rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:hasFormat>
+    <dc:hasPart rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:hasPart>
+    <dc:hasVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:hasVersion>
+    <dc:identifier rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:identifier>
+    <dc:isFormatOf rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isFormatOf>
+    <dc:isPartOf rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isPartOf>
+    <dc:isReferencedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isReferencedBy>
+    <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:issued>
+    <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:language>
+    <dc:license rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:license>
+    <dc:modified rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:modified>
+    <dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:publisher>
+    <dc:relation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:relation>
+    <dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rights>
+    <dc:rightsHolder rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rightsHolder>
+    <dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:source>
+    <dc:subject rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:subject>
+    <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
+    <dc:type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:type>
+    <ns0:createdWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns0:createdWith>
+    <ns0:curatedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns0:curatedBy>
+    <void:classPartition rdf:resource="https://example.org/voidDataset/voidDatasetID"/>
+    <void:exampleResource rdf:resource="https://example.org/Resource/ResourceID"/>
+    <void:openSearchDescription rdf:resource="https://example.org/Document/DocumentID"/>
+    <void:propertyPartition rdf:resource="https://example.org/voidDataset/voidDatasetID"/>
+    <void:rootResource rdf:resource="https://example.org/Resource/ResourceID"/>
+    <void:uriLookupEndpoint rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org</void:uriLookupEndpoint>
+    <void:uriRegexPattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</void:uriRegexPattern>
+    <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</doap:bug-database>
+    <doap:mailing-list rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</doap:mailing-list>
+    <doap:repository>
+      <doap:repository rdf:about="https://example.org/repository/repositoryID">
+      </doap:repository>
+    </doap:repository>
+
+    <rdfs:comment rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</rdfs:comment>
+    <owl:backwardCompatibleWith rdf:resource="https://example.org/Ontology/OntologyID"/>
+    <owl:deprecated rdf:resource="https://example.org/Resource/ResourceID"/>
+    <owl:incompatibleWith rdf:resource="https://example.org/Ontology/OntologyID"/>
+    <owl:priorVersion rdf:resource="https://example.org/Ontology/OntologyID"/>
+    <owl:versionIRI rdf:resource="https://example.org/Ontology/OntologyID"/>
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</owl:versionInfo>
+    <skos:hiddenLabel rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</skos:hiddenLabel>
+    <dcat:contactPoint>
+      <vcard:Kind rdf:about="https://example.org/vcardKind/vcardKindID">
+        <vcard:fn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corky Crystal</vcard:fn>
+        <vcard:nickname rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corks</vcard:nickname>
+      </vcard:Kind>
+    </dcat:contactPoint>
+
+    <dcat:keyword rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:keyword>
+    <dcat:landingPage rdf:resource="https://example.org/Document/DocumentID"/>
+    <dcat:qualifiedRelation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:qualifiedRelation>
+    <odrl:hasPolicy>
+      <odrl:Policy rdf:about="https://example.org/Policy/PolicyID">
+      </odrl:Policy>
+    </odrl:hasPolicy>
+
+    <prov:qualifiedAttribution>
+      <prov:Attribution rdf:about="https://example.org/Attribution/AttributionID">
+      </prov:Attribution>
+    </prov:qualifiedAttribution>
+
+    <prov:wasGeneratedBy rdf:resource="https://example.org/Activity/ActivityID"/>
+    <prov:wasInvalidatedBy rdf:resource="https://example.org/Activity/ActivityID"/>
+    <foaf:depiction>
+      <foaf:Image rdf:about="https://example.org/Image/ImageID">
+      </foaf:Image>
+    </foaf:depiction>
+
+    <foaf:fundedBy rdf:resource="https://example.org/Thing/ThingID"/>
+    <foaf:homepage rdf:resource="https://example.org/Document/DocumentID"/>
+    <foaf:logo rdf:resource="https://example.org/Thing/ThingID"/>
+    <foaf:primaryTopic rdf:resource="https://example.org/Thing/ThingID"/>
+    <ns1:associatedMedia rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:associatedMedia>
+    <ns1:award rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:award>
+    <ns1:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:comment>
+    <ns1:funding rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:funding>
+    <ns1:includedInDataCatalog rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:includedInDataCatalog>
+    <ns1:translationOfWork rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:translationOfWork>
+    <ns1:translator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:translator>
+    <ns1:workTranslation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:workTranslation>
+    <ns2:changes rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:changes>
+    <ns2:example rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:example>
+    <ns2:preferredNamespacePrefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:preferredNamespacePrefix>
+    <ns2:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:preferredNamespaceUri>
+    <ns3:URI rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org</ns3:URI>
+    <ns3:acronym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns3:acronym>
+    <ns3:analytics>
+      <ns3:Analytics rdf:about="https://example.org/Analytics/AnalyticsID">
+      </ns3:Analytics>
+    </ns3:analytics>
+
+    <ns3:comesFromTheSameDomain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:comesFromTheSameDomain>
+    <ns3:competencyQuestion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns3:competencyQuestion>
+    <ns3:designedForTask>
+      <ns3:SemanticArtefactTask rdf:about="https://example.org/SemanticArtefactTask/SemanticArtefactTaskID">
+      </ns3:SemanticArtefactTask>
+    </ns3:designedForTask>
+
+    <ns3:endorsedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:endorsedBy>
+    <ns3:generalizes rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:generalizes>
+    <ns3:group>
+      <ns3:Group rdf:about="https://example.org/Group/GroupID">
+      </ns3:Group>
+    </ns3:group>
+
+    <ns3:hasDisjunctionsWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:hasDisjunctionsWith>
+    <ns3:hasDisparateModelling rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:hasDisparateModelling>
+    <ns3:hasEquivalencesWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:hasEquivalencesWith>
+    <ns3:hasEvaluation>
+      <ns3:Evaluation rdf:about="https://example.org/Evaluation/EvaluationID">
+      </ns3:Evaluation>
+    </ns3:hasEvaluation>
+
+    <ns3:knownUsage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns3:knownUsage>
+    <ns3:metrics rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns3:metrics>
+    <ns3:numberOfAgents rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns3:numberOfAgents>
+    <ns3:numberOfEndorsements rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns3:numberOfEndorsements>
+    <ns3:numberOfEvaluations rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns3:numberOfEvaluations>
+    <ns3:numberOfNotes rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns3:numberOfNotes>
+    <ns3:numberOfUsers rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns3:numberOfUsers>
+    <ns3:numberOfUsingProjects rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns3:numberOfUsingProjects>
+    <ns3:reliesOn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:reliesOn>
+    <ns3:semanticArtefactRelation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:semanticArtefactRelation>
+    <ns3:similar rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:similar>
+    <ns3:specializes rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:specializes>
+    <ns3:status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns3:status>
+    <ns3:toDoList>
+      <rdf:Description rdf:about="https://example.org/Vtodo/VtodoID">
+        <rdf:type rdf:resource="http://www.w3.org/2002/12/cal/ical#Vtodo"/>
+      </rdf:Description>
+    </ns3:toDoList>
+
+    <ns3:usedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:usedBy>
+    <ns3:usedInProject>
+      <foaf:Project rdf:about="https://example.org/Project/ProjectID">
+      </foaf:Project>
+    </ns3:usedInProject>
+
+  </rdf:Description>
+
+  <rdfs:Resource rdf:about="https://example.org/Resource/ResourceID">
+  </rdfs:Resource>
+
+  <void:dataset rdf:about="https://example.org/voidDataset/voidDatasetID">
+  </void:dataset>
+
+  <foaf:Document rdf:about="https://example.org/Document/DocumentID">
+  </foaf:Document>
+
+  <owl:Ontology rdf:about="https://example.org/Ontology/OntologyID">
+  </owl:Ontology>
+
+  <prov:Activity rdf:about="https://example.org/Activity/ActivityID">
+  </prov:Activity>
+
+  <owl:Thing rdf:about="https://example.org/Thing/ThingID">
+  </owl:Thing>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/artefacts.xml
+++ b/mod_api/static/mod_api/xml/artefacts.xml
@@ -55,7 +55,6 @@
         <dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rights>
         <dc:rightsHolder rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rightsHolder>
         <dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:source>
-        <dc:subject rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:subject>
         <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
         <dc:type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:type>
         <ns1:createdWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:createdWith>
@@ -91,7 +90,16 @@
 
         <dcat:keyword rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:keyword>
         <dcat:landingPage rdf:resource="https://example.org/Document/DocumentID"/>
-        <dcat:qualifiedRelation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:qualifiedRelation>
+        <dcat:qualifiedRelation>
+          <dcat:Relationship rdf:about="https://example.org/Relationship/RelationshipID">
+          </dcat:Relationship>
+        </dcat:qualifiedRelation>
+
+        <dcat:theme>
+          <rdfs:Resource rdf:about="https://example.org/Theme/ThemeID">
+          </rdfs:Resource>
+        </dcat:theme>
+
         <odrl:hasPolicy>
           <odrl:Policy rdf:about="https://example.org/Policy/PolicyID">
           </odrl:Policy>

--- a/mod_api/static/mod_api/xml/artefacts.xml
+++ b/mod_api/static/mod_api/xml/artefacts.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:cc="http://creativecommons.org/ns#"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:ns1="http://purl.org/pav/"
+         xmlns:void="http://rdfs.org/ns/void#"
+         xmlns:doap="http://usefulinc.com/ns/doap#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+         xmlns:odrl="http://www.w3.org/ns/odrl/2/"
+         xmlns:prov="http://www.w3.org/ns/prov#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:ns2="https://schema.org/"
+         xmlns:ns3="https://vocab.org/vann/"
+         xmlns:ns4="https://w3id.org/mod#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <rdf:Description rdf:about="https://example.org/SemanticArtefact/SemanticArtefactID">
+        <rdf:type rdf:resource="https://w3id.org/mod#SemanticArtefact"/>
+        <cc:morePermissions rdf:resource="https://example.org/Resource/ResourceID"/>
+        <cc:useGuidelines rdf:resource="https://example.org/Resource/ResourceID"/>
+        <dc:abstract rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:abstract>
+        <dc:accessRights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accessRights>
+        <dc:accrualMethod rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualMethod>
+        <dc:accrualPeriodicity rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualPeriodicity>
+        <dc:accrualPolicy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualPolicy>
+        <dc:alternative rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:alternative>
+        <dc:audience rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:audience>
+        <dc:bibliographicCitation rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:bibliographicCitation>
+        <dc:conformsTo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:conformsTo>
+        <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:contributor>
+        <dc:coverage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:coverage>
+        <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:creator>
+        <dc:description rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:description>
+        <dc:hasFormat rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:hasFormat>
+        <dc:hasPart rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:hasPart>
+        <dc:hasVersion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:hasVersion>
+        <dc:identifier rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:identifier>
+        <dc:isFormatOf rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isFormatOf>
+        <dc:isPartOf rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isPartOf>
+        <dc:isReferencedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isReferencedBy>
+        <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:issued>
+        <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:language>
+        <dc:license rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:license>
+        <dc:modified rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:modified>
+        <dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:publisher>
+        <dc:relation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:relation>
+        <dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rights>
+        <dc:rightsHolder rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rightsHolder>
+        <dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:source>
+        <dc:subject rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:subject>
+        <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
+        <dc:type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:type>
+        <ns1:createdWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:createdWith>
+        <ns1:curatedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:curatedBy>
+        <void:classPartition rdf:resource="https://example.org/voidDataset/voidDatasetID"/>
+        <void:exampleResource rdf:resource="https://example.org/Resource/ResourceID"/>
+        <void:openSearchDescription rdf:resource="https://example.org/Document/DocumentID"/>
+        <void:propertyPartition rdf:resource="https://example.org/voidDataset/voidDatasetID"/>
+        <void:rootResource rdf:resource="https://example.org/Resource/ResourceID"/>
+        <void:uriLookupEndpoint rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org</void:uriLookupEndpoint>
+        <void:uriRegexPattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</void:uriRegexPattern>
+        <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</doap:bug-database>
+        <doap:mailing-list rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</doap:mailing-list>
+        <doap:repository>
+          <doap:repository rdf:about="https://example.org/repository/repositoryID">
+          </doap:repository>
+        </doap:repository>
+
+        <rdfs:comment rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</rdfs:comment>
+        <owl:backwardCompatibleWith rdf:resource="https://example.org/Ontology/OntologyID"/>
+        <owl:deprecated rdf:resource="https://example.org/Resource/ResourceID"/>
+        <owl:incompatibleWith rdf:resource="https://example.org/Ontology/OntologyID"/>
+        <owl:priorVersion rdf:resource="https://example.org/Ontology/OntologyID"/>
+        <owl:versionIRI rdf:resource="https://example.org/Ontology/OntologyID"/>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</owl:versionInfo>
+        <skos:hiddenLabel rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</skos:hiddenLabel>
+        <dcat:contactPoint>
+          <vcard:Kind rdf:about="https://example.org/vcardKind/vcardKindID">
+            <vcard:fn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corky Crystal</vcard:fn>
+            <vcard:nickname rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corks</vcard:nickname>
+          </vcard:Kind>
+        </dcat:contactPoint>
+
+        <dcat:keyword rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:keyword>
+        <dcat:landingPage rdf:resource="https://example.org/Document/DocumentID"/>
+        <dcat:qualifiedRelation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:qualifiedRelation>
+        <odrl:hasPolicy>
+          <odrl:Policy rdf:about="https://example.org/Policy/PolicyID">
+          </odrl:Policy>
+        </odrl:hasPolicy>
+
+        <prov:qualifiedAttribution>
+          <prov:Attribution rdf:about="https://example.org/Attribution/AttributionID">
+          </prov:Attribution>
+        </prov:qualifiedAttribution>
+
+        <prov:wasGeneratedBy rdf:resource="https://example.org/Activity/ActivityID"/>
+        <prov:wasInvalidatedBy rdf:resource="https://example.org/Activity/ActivityID"/>
+        <foaf:depiction>
+          <foaf:Image rdf:about="https://example.org/Image/ImageID">
+          </foaf:Image>
+        </foaf:depiction>
+
+        <foaf:fundedBy rdf:resource="https://example.org/Thing/ThingID"/>
+        <foaf:homepage rdf:resource="https://example.org/Document/DocumentID"/>
+        <foaf:logo rdf:resource="https://example.org/Thing/ThingID"/>
+        <foaf:primaryTopic rdf:resource="https://example.org/Thing/ThingID"/>
+        <ns2:associatedMedia rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:associatedMedia>
+        <ns2:award rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:award>
+        <ns2:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:comment>
+        <ns2:funding rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:funding>
+        <ns2:includedInDataCatalog rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:includedInDataCatalog>
+        <ns2:translationOfWork rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:translationOfWork>
+        <ns2:translator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:translator>
+        <ns2:workTranslation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:workTranslation>
+        <ns3:changes rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:changes>
+        <ns3:example rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:example>
+        <ns3:preferredNamespacePrefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:preferredNamespacePrefix>
+        <ns3:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:preferredNamespaceUri>
+        <ns4:URI rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org</ns4:URI>
+        <ns4:acronym rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns4:acronym>
+        <ns4:analytics>
+          <ns4:Analytics rdf:about="https://example.org/Analytics/AnalyticsID">
+          </ns4:Analytics>
+        </ns4:analytics>
+
+        <ns4:comesFromTheSameDomain rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:comesFromTheSameDomain>
+        <ns4:competencyQuestion rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns4:competencyQuestion>
+        <ns4:designedForTask>
+          <ns4:SemanticArtefactTask rdf:about="https://example.org/SemanticArtefactTask/SemanticArtefactTaskID">
+          </ns4:SemanticArtefactTask>
+        </ns4:designedForTask>
+
+        <ns4:endorsedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:endorsedBy>
+        <ns4:generalizes rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:generalizes>
+        <ns4:group>
+          <ns4:Group rdf:about="https://example.org/Group/GroupID">
+          </ns4:Group>
+        </ns4:group>
+
+        <ns4:hasDisjunctionsWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:hasDisjunctionsWith>
+        <ns4:hasDisparateModelling rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:hasDisparateModelling>
+        <ns4:hasEquivalencesWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:hasEquivalencesWith>
+        <ns4:hasEvaluation>
+          <ns4:Evaluation rdf:about="https://example.org/Evaluation/EvaluationID">
+          </ns4:Evaluation>
+        </ns4:hasEvaluation>
+
+        <ns4:knownUsage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns4:knownUsage>
+        <ns4:metrics rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:metrics>
+        <ns4:numberOfAgents rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfAgents>
+        <ns4:numberOfEndorsements rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfEndorsements>
+        <ns4:numberOfEvaluations rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfEvaluations>
+        <ns4:numberOfNotes rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfNotes>
+        <ns4:numberOfUsers rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfUsers>
+        <ns4:numberOfUsingProjects rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfUsingProjects>
+        <ns4:reliesOn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:reliesOn>
+        <ns4:semanticArtefactRelation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:semanticArtefactRelation>
+        <ns4:similar rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:similar>
+        <ns4:specializes rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:specializes>
+        <ns4:status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns4:status>
+        <ns4:toDoList>
+          <rdf:Description rdf:about="https://example.org/Vtodo/VtodoID">
+            <rdf:type rdf:resource="http://www.w3.org/2002/12/cal/ical#Vtodo"/>
+          </rdf:Description>
+        </ns4:toDoList>
+
+        <ns4:usedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:usedBy>
+        <ns4:usedInProject>
+          <foaf:Project rdf:about="https://example.org/Project/ProjectID">
+          </foaf:Project>
+        </ns4:usedInProject>
+
+      </rdf:Description>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+  <rdfs:Resource rdf:about="https://example.org/Resource/ResourceID">
+  </rdfs:Resource>
+
+  <void:dataset rdf:about="https://example.org/voidDataset/voidDatasetID">
+  </void:dataset>
+
+  <foaf:Document rdf:about="https://example.org/Document/DocumentID">
+  </foaf:Document>
+
+  <owl:Ontology rdf:about="https://example.org/Ontology/OntologyID">
+  </owl:Ontology>
+
+  <prov:Activity rdf:about="https://example.org/Activity/ActivityID">
+  </prov:Activity>
+
+  <owl:Thing rdf:about="https://example.org/Thing/ThingID">
+  </owl:Thing>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/catalog.xml
+++ b/mod_api/static/mod_api/xml/catalog.xml
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:cc="http://creativecommons.org/ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:ns0="http://purl.org/pav/"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:void="http://rdfs.org/ns/void#"
+         xmlns:doap="http://usefulinc.com/ns/doap#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+         xmlns:ns1="http://www.w3.org/ns/adms#"
+         xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+         xmlns:odrl="http://www.w3.org/ns/odrl/2/"
+         xmlns:prov="http://www.w3.org/ns/prov#"
+         xmlns:sd="http://www.w3.org/ns/sparql-service-description#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:ns2="https://schema.org/"
+         xmlns:ns3="https://vocab.org/vann/"
+         xmlns:ns4="https://w3id.org/mod#">
+
+  <rdf:Description rdf:about="https://example.org/SemanticArtefactCatalog/SemanticArtefactCatalogID">
+    <rdf:type rdf:resource="https://w3id.org/mod#SemanticArtefactCatalog"/>
+    <cc:morePermissions>
+      <rdfs:Resource rdf:about="https://example.org/Resource/MorePermissionsResourceID">
+      </rdfs:Resource>
+    </cc:morePermissions>
+
+    <cc:useGuidelines>
+      <rdfs:Resource rdf:about="https://example.org/Resource/UseGuidelinesResourceID">
+      </rdfs:Resource>
+    </cc:useGuidelines>
+
+    <dc:abstract rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:abstract>
+    <dc:accessRights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accessRights>
+    <dc:accrualMethod rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualMethod>
+    <dc:accrualPeriodicity rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualPeriodicity>
+    <dc:accrualPolicy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accrualPolicy>
+    <dc:alternative rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:alternative>
+    <dc:audience rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:audience>
+    <dc:bibliographicCitation rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:bibliographicCitation>
+    <dc:conformsTo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:conformsTo>
+    <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:contributor>
+    <dc:coverage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:coverage>
+    <dc:created rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:created>
+    <dc:creator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:creator>
+    <dc:description rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:description>
+    <dc:hasPart>
+      <dcat:Resource rdf:about="https://example.org/Resource/ResourceID">
+      </dcat:Resource>
+    </dc:hasPart>
+
+    <dc:identifier rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:identifier>
+    <dc:isPartOf rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isPartOf>
+    <dc:isReferencedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:isReferencedBy>
+    <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:issued>
+    <dc:language rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:language>
+    <dc:license rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:license>
+    <dc:modified rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:modified>
+    <dc:publisher rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:publisher>
+    <dc:relation rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:relation>
+    <dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rights>
+    <dc:rightsHolder rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rightsHolder>
+    <dc:source rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:source>
+    <dc:spatial rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:spatial>
+    <dc:temporal rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:temporal>
+    <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
+    <dc:type rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:type>
+    <ns0:createdWith rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns0:createdWith>
+    <ns0:curatedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns0:curatedBy>
+    <ns0:curatedOn>
+      <xsd:date>
+      </xsd:date>
+    </ns0:curatedOn>
+
+    <void:openSearchDescription rdf:resource="https://example.org/Document/DocumentID"/>
+    <void:uriLookupEndpoint rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/uriLookupEndpoint</void:uriLookupEndpoint>
+    <void:uriRegexPattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</void:uriRegexPattern>
+    <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</doap:bug-database>
+    <doap:mailing-list rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</doap:mailing-list>
+    <doap:repository>
+      <doap:repository rdf:about="https://example.org/repository/repositoryID">
+      </doap:repository>
+    </doap:repository>
+
+    <rdfs:comment rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</rdfs:comment>
+    <owl:deprecated>
+      <rdfs:Resource rdf:about="https://example.org/Resource/DeprecatedResourceID">
+      </rdfs:Resource>
+    </owl:deprecated>
+
+    <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</owl:versionInfo>
+    <skos:hiddenLabel rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</skos:hiddenLabel>
+    <ns1:supportedSchema>
+      <ns1:Asset rdf:about="https://example.org/asset/assetId">
+      </ns1:Asset>
+    </ns1:supportedSchema>
+
+    <dcat:accessURL>
+      <rdfs:Resource rdf:about="https://example.org/Resource/AccessURLResourceID">
+      </rdfs:Resource>
+    </dcat:accessURL>
+
+    <dcat:catalog>
+      <dcat:Catalog rdf:about="https://example.org/Catalog/CatalogID">
+      </dcat:Catalog>
+    </dcat:catalog>
+
+    <dcat:contactPoint>
+      <vcard:Kind rdf:about="https://example.org/vcardKind/vcardKindID">
+        <vcard:fn rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corky Crystal</vcard:fn>
+        <vcard:nickname rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Corks</vcard:nickname>
+      </vcard:Kind>
+    </dcat:contactPoint>
+
+    <dcat:dataset>
+      <dcat:Dataset rdf:about="https://example.org/Dataset/DatasetID">
+      </dcat:Dataset>
+    </dcat:dataset>
+
+    <dcat:distribution>
+      <dcat:Distribution rdf:about="https://example.org/Distribution/DistributionID">
+      </dcat:Distribution>
+    </dcat:distribution>
+
+    <dcat:keyword rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:keyword>
+    <dcat:landingPage rdf:resource="https://example.org/Document/DocumentID"/>
+    <dcat:qualifiedRelation>
+      <dcat:Relationship rdf:about="https://example.org/Relationship/RelationshipID">
+      </dcat:Relationship>
+    </dcat:qualifiedRelation>
+
+    <dcat:record>
+      <dcat:CatalogRecord rdf:about="https://example.org/CatalogRecord/CatalogRecordID">
+      </dcat:CatalogRecord>
+    </dcat:record>
+
+    <dcat:service>
+      <dcat:DataService rdf:about="https://example.org/DataService/DataServiceID">
+      </dcat:DataService>
+    </dcat:service>
+
+    <dcat:spatialResolutionInMeters rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:spatialResolutionInMeters>
+    <dcat:temporalResolution rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:temporalResolution>
+    <dcat:theme>
+      <rdfs:Resource rdf:about="https://example.org/Theme/ThemeID">
+      </rdfs:Resource>
+    </dcat:theme>
+
+    <dcat:themeTaxonomy>
+      <rdfs:Resource rdf:about="https://example.org/Resource/ThemeTaxonomyResourceID">
+      </rdfs:Resource>
+    </dcat:themeTaxonomy>
+
+    <odrl:hasPolicy>
+      <odrl:Policy rdf:about="https://example.org/Policy/PolicyID">
+      </odrl:Policy>
+    </odrl:hasPolicy>
+
+    <prov:qualifiedAttribution>
+      <prov:Attribution rdf:about="https://example.org/Attribution/AttributionID">
+      </prov:Attribution>
+    </prov:qualifiedAttribution>
+
+    <prov:wasGeneratedBy>
+      <prov:Activity rdf:about="https://example.org/Activity/ActivityID">
+      </prov:Activity>
+    </prov:wasGeneratedBy>
+
+    <sd:endpoint rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</sd:endpoint>
+    <foaf:depiction>
+      <foaf:Image rdf:about="https://example.org/Image/ImageID">
+      </foaf:Image>
+    </foaf:depiction>
+
+    <foaf:fundedBy rdf:resource="https://example.org/Thing/ThingID"/>
+    <foaf:homepage rdf:resource="https://example.org/Document/DocumentID"/>
+    <foaf:logo rdf:resource="https://example.org/Thing/ThingID"/>
+    <ns2:associatedMedia rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:associatedMedia>
+    <ns2:award rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:award>
+    <ns2:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:comment>
+    <ns2:funding rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:funding>
+    <ns2:publishingPrinciples rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:publishingPrinciples>
+    <ns2:translator rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns2:translator>
+    <ns3:changes rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:changes>
+    <ns3:example rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:example>
+    <ns3:preferredNamespacePrefix rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:preferredNamespacePrefix>
+    <ns3:preferredNamespaceUri rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns3:preferredNamespaceUri>
+    <ns4:analytics>
+      <ns4:Analytics rdf:about="https://example.org/Analytics/AnalyticsID">
+      </ns4:Analytics>
+    </ns4:analytics>
+
+    <ns4:endorsedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns4:endorsedBy>
+    <ns4:fairScore rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:fairScore>
+    <ns4:group>
+      <ns4:Group rdf:about="https://example.org/Group/GroupID">
+      </ns4:Group>
+    </ns4:group>
+
+    <ns4:knownUsage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns4:knownUsage>
+    <ns4:metadataVoc rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/metadataVoc</ns4:metadataVoc>
+    <ns4:metrics rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:metrics>
+    <ns4:numberOfAgents rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfAgents>
+    <ns4:numberOfArtefacts rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfArtefacts>
+    <ns4:numberOfAxioms rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfAxioms>
+    <ns4:numberOfClasses rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfClasses>
+    <ns4:numberOfDataProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfDataProperties>
+    <ns4:numberOfDeprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfDeprecated>
+    <ns4:numberOfEndorsements rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfEndorsements>
+    <ns4:numberOfIndividuals rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfIndividuals>
+    <ns4:numberOfLabels rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfLabels>
+    <ns4:numberOfMappings rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfMappings>
+    <ns4:numberOfObjectProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfObjectProperties>
+    <ns4:numberOfProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfProperties>
+    <ns4:numberOfUsers rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfUsers>
+    <ns4:numberOfUsingProjects rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns4:numberOfUsingProjects>
+    <ns4:status rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns4:status>
+    <ns4:toDoList>
+      <rdf:Description rdf:about="https://example.org/Vtodo/VtodoID">
+        <rdf:type rdf:resource="http://www.w3.org/2002/12/cal/ical#Vtodo"/>
+      </rdf:Description>
+    </ns4:toDoList>
+
+    <ns4:usedInProject>
+      <foaf:Project rdf:about="https://example.org/Project/ProjectID">
+      </foaf:Project>
+    </ns4:usedInProject>
+
+  </rdf:Description>
+
+  <foaf:Document rdf:about="https://example.org/Document/DocumentID">
+  </foaf:Document>
+
+  <owl:Thing rdf:about="https://example.org/Thing/ThingID">
+  </owl:Thing>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/classes.xml
+++ b/mod_api/static/mod_api/xml/classes.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <owl:Class rdf:about="https://example.org/Class/ClassID1">
+      </owl:Class>
+    </ns0:member>
+
+    <ns0:member>
+      <owl:Class rdf:about="https://example.org/Class/ClassID2">
+      </owl:Class>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/collections.xml
+++ b/mod_api/static/mod_api/xml/collections.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <skos:Collection rdf:about="https://example.org/skosCollection/skosCollectionID1">
+        <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">collection of cars</skos:prefLabel>
+      </skos:Collection>
+    </ns0:member>
+
+    <ns0:member>
+      <skos:Collection rdf:about="https://example.org/skosCollection/skosCollectionID2">
+        <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">collection of cats</skos:prefLabel>
+      </skos:Collection>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/concepts.xml
+++ b/mod_api/static/mod_api/xml/concepts.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <skos:Concept rdf:about="https://example.org/skosConcept/skosConceptID1">
+        <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cars</skos:prefLabel>
+      </skos:Concept>
+    </ns0:member>
+
+    <ns0:member>
+      <skos:Concept rdf:about="https://example.org/skosConcept/skosConceptID2">
+        <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cats</skos:prefLabel>
+      </skos:Concept>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/distribution.xml
+++ b/mod_api/static/mod_api/xml/distribution.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:cc="http://creativecommons.org/ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:ns0="http://purl.org/pav/"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:odrl="http://www.w3.org/ns/odrl/2/"
+         xmlns:sd="http://www.w3.org/ns/sparql-service-description#"
+         xmlns:ns1="https://w3id.org/mod#">
+
+  <rdf:Description rdf:about="https://example.org/SemanticArtefactDistribution/SemanticArtefactDistributionID">
+    <rdf:type rdf:resource="https://w3id.org/mod#SemanticArtefactDistribution"/>
+    <cc:useGuidelines>
+      <rdfs:Resource rdf:about="https://example.org/Resource/UseGuidelinesResourceID">
+      </rdfs:Resource>
+    </cc:useGuidelines>
+
+    <dc:accessRights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accessRights>
+    <dc:conformsTo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:conformsTo>
+    <dc:created rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:created>
+    <dc:dateSubmitted rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:dateSubmitted>
+    <dc:description rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:description>
+    <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:format>
+    <dc:issued rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:issued>
+    <dc:license rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:license>
+    <dc:modified rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:modified>
+    <dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rights>
+    <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
+    <dc:valid rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:valid>
+    <ns0:curatedOn>
+      <xsd:date>
+      </xsd:date>
+    </ns0:curatedOn>
+
+    <owl:deprecated>
+      <rdfs:Resource rdf:about="https://example.org/Resource/DeprecatedResourceID">
+      </rdfs:Resource>
+    </owl:deprecated>
+
+    <owl:imports>
+      <owl:Ontology rdf:about="https://example.org/Ontology/OntologyID">
+      </owl:Ontology>
+    </owl:imports>
+
+    <dcat:accessService>
+      <dcat:DataService rdf:about="https://example.org/DataService/DataServiceID">
+      </dcat:DataService>
+    </dcat:accessService>
+
+    <dcat:accessURL>
+      <rdfs:Resource rdf:about="https://example.org/Resource/AccessURLResourceID">
+      </rdfs:Resource>
+    </dcat:accessURL>
+
+    <dcat:byteSize rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:byteSize>
+    <dcat:compressFormat rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:compressFormat>
+    <dcat:downloadURL>
+      <rdfs:Resource rdf:about="https://example.org/Resource/DownloadURLResourceID">
+      </rdfs:Resource>
+    </dcat:downloadURL>
+
+    <dcat:mediaType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:mediaType>
+    <dcat:packageFormat rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:packageFormat>
+    <dcat:spatialResolutionInMeters rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:spatialResolutionInMeters>
+    <dcat:temporalResolution rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:temporalResolution>
+    <odrl:hasPolicy>
+      <odrl:Policy rdf:about="https://example.org/Policy/PolicyID">
+      </odrl:Policy>
+    </odrl:hasPolicy>
+
+    <sd:endpoint rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</sd:endpoint>
+    <ns1:FairAssessment>
+      <rdf:Description rdf:about="https://example.org/FairAssessment/FairAssessmentID">
+        <rdf:type rdf:resource="http://njh.me/FairAssessment"/>
+      </rdf:Description>
+    </ns1:FairAssessment>
+
+    <ns1:authorProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/authorProperty</ns1:authorProperty>
+    <ns1:averageChildCount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">4.0</ns1:averageChildCount>
+    <ns1:browsingUI rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/browsingUI</ns1:browsingUI>
+    <ns1:classesWithMoreThan25Children rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:classesWithMoreThan25Children>
+    <ns1:classesWithNoAuthorMetadata rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:classesWithNoAuthorMetadata>
+    <ns1:classesWithNoDateMetadata rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:classesWithNoDateMetadata>
+    <ns1:classesWithNoDefinition rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:classesWithNoDefinition>
+    <ns1:classesWithNoFormalDefinition rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:classesWithNoFormalDefinition>
+    <ns1:classesWithNoLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:classesWithNoLabel>
+    <ns1:classesWithOneChild rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:classesWithOneChild>
+    <ns1:conformsToKnowledgeRepresentationParadigm>
+      <ns1:KnowledgeRepresentationParadigm rdf:about="https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID">
+      </ns1:KnowledgeRepresentationParadigm>
+    </ns1:conformsToKnowledgeRepresentationParadigm>
+
+    <ns1:createdProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/createdProperty</ns1:createdProperty>
+    <ns1:definitionProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/definitionProperty</ns1:definitionProperty>
+    <ns1:fairScore rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:fairScore>
+    <ns1:hasFormalityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns1:hasFormalityLevel>
+    <ns1:hasRepresentationLanguage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns1:hasRepresentationLanguage>
+    <ns1:hasSyntax rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/hasSyntax</ns1:hasSyntax>
+    <ns1:hierarchyProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/hierarchyProperty</ns1:hierarchyProperty>
+    <ns1:maxChildCount rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:maxChildCount>
+    <ns1:maxDepth rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:maxDepth>
+    <ns1:metadataVoc rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/metadataVoc</ns1:metadataVoc>
+    <ns1:metrics rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:metrics>
+    <ns1:modifiedProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/modifiedProperty</ns1:modifiedProperty>
+    <ns1:numberOfAxioms rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfAxioms>
+    <ns1:numberOfClasses rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</ns1:numberOfClasses>
+    <ns1:numberOfDataProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfDataProperties>
+    <ns1:numberOfDeprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfDeprecated>
+    <ns1:numberOfIndividuals rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfIndividuals>
+    <ns1:numberOfLabels rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfLabels>
+    <ns1:numberOfMappings rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfMappings>
+    <ns1:numberOfObjectProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfObjectProperties>
+    <ns1:numberOfProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfProperties>
+    <ns1:obsoleteParent rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/obsoleteParent</ns1:obsoleteParent>
+    <ns1:obsoleteProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/obsoleteProperty</ns1:obsoleteProperty>
+    <ns1:prefLabelProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/prefLabelProperty</ns1:prefLabelProperty>
+    <ns1:sampleQueries rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/sampleQueries</ns1:sampleQueries>
+    <ns1:synonymProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/synonymProperty</ns1:synonymProperty>
+    <ns1:usedEngineeringMethodology>
+      <ns1:EngineeringMethodology rdf:about="https://example.org/EngineeringMethodology/EngineeringMethodologyID">
+      </ns1:EngineeringMethodology>
+    </ns1:usedEngineeringMethodology>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/distribution.xml
+++ b/mod_api/static/mod_api/xml/distribution.xml
@@ -106,7 +106,7 @@
     <ns1:metrics rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:metrics>
     <ns1:modifiedProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/modifiedProperty</ns1:modifiedProperty>
     <ns1:numberOfAxioms rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfAxioms>
-    <ns1:numberOfClasses rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</ns1:numberOfClasses>
+    <ns1:numberOfClasses rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfClasses>
     <ns1:numberOfDataProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfDataProperties>
     <ns1:numberOfDeprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfDeprecated>
     <ns1:numberOfIndividuals rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns1:numberOfIndividuals>

--- a/mod_api/static/mod_api/xml/distributions.xml
+++ b/mod_api/static/mod_api/xml/distributions.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:cc="http://creativecommons.org/ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:ns1="http://purl.org/pav/"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#"
+         xmlns:dcat="http://www.w3.org/ns/dcat#"
+         xmlns:odrl="http://www.w3.org/ns/odrl/2/"
+         xmlns:sd="http://www.w3.org/ns/sparql-service-description#"
+         xmlns:ns2="https://w3id.org/mod#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <rdf:Description rdf:about="https://example.org/SemanticArtefactDistribution/SemanticArtefactDistributionID">
+        <rdf:type rdf:resource="https://w3id.org/mod#SemanticArtefactDistribution"/>
+        <cc:useGuidelines>
+          <rdfs:Resource rdf:about="https://example.org/Resource/UseGuidelinesResourceID">
+          </rdfs:Resource>
+        </cc:useGuidelines>
+
+        <dc:accessRights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:accessRights>
+        <dc:conformsTo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:conformsTo>
+        <dc:created rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:created>
+        <dc:dateSubmitted rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:dateSubmitted>
+        <dc:description rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:description>
+        <dc:format rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:format>
+        <dc:issued rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:issued>
+        <dc:license rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:license>
+        <dc:modified rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:modified>
+        <dc:rights rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:rights>
+        <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
+        <dc:valid rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:valid>
+        <ns1:curatedOn>
+          <xsd:date>
+          </xsd:date>
+        </ns1:curatedOn>
+
+        <owl:deprecated>
+          <rdfs:Resource rdf:about="https://example.org/Resource/DeprecatedResourceID">
+          </rdfs:Resource>
+        </owl:deprecated>
+
+        <owl:imports>
+          <owl:Ontology rdf:about="https://example.org/Ontology/OntologyID">
+          </owl:Ontology>
+        </owl:imports>
+
+        <dcat:accessService>
+          <dcat:DataService rdf:about="https://example.org/DataService/DataServiceID">
+          </dcat:DataService>
+        </dcat:accessService>
+
+        <dcat:accessURL>
+          <rdfs:Resource rdf:about="https://example.org/Resource/AccessURLResourceID">
+          </rdfs:Resource>
+        </dcat:accessURL>
+
+        <dcat:byteSize rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:byteSize>
+        <dcat:compressFormat rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:compressFormat>
+        <dcat:downloadURL>
+          <rdfs:Resource rdf:about="https://example.org/Resource/DownloadURLResourceID">
+          </rdfs:Resource>
+        </dcat:downloadURL>
+
+        <dcat:mediaType rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:mediaType>
+        <dcat:packageFormat rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:packageFormat>
+        <dcat:spatialResolutionInMeters rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:spatialResolutionInMeters>
+        <dcat:temporalResolution rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dcat:temporalResolution>
+        <odrl:hasPolicy>
+          <odrl:Policy rdf:about="https://example.org/Policy/PolicyID">
+          </odrl:Policy>
+        </odrl:hasPolicy>
+
+        <sd:endpoint rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</sd:endpoint>
+        <ns2:FairAssessment>
+          <rdf:Description rdf:about="https://example.org/FairAssessment/FairAssessmentID">
+            <rdf:type rdf:resource="http://njh.me/FairAssessment"/>
+          </rdf:Description>
+        </ns2:FairAssessment>
+
+        <ns2:authorProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/authorProperty</ns2:authorProperty>
+        <ns2:averageChildCount rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">4.0</ns2:averageChildCount>
+        <ns2:browsingUI rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/browsingUI</ns2:browsingUI>
+        <ns2:classesWithMoreThan25Children rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:classesWithMoreThan25Children>
+        <ns2:classesWithNoAuthorMetadata rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:classesWithNoAuthorMetadata>
+        <ns2:classesWithNoDateMetadata rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:classesWithNoDateMetadata>
+        <ns2:classesWithNoDefinition rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:classesWithNoDefinition>
+        <ns2:classesWithNoFormalDefinition rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:classesWithNoFormalDefinition>
+        <ns2:classesWithNoLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:classesWithNoLabel>
+        <ns2:classesWithOneChild rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:classesWithOneChild>
+        <ns2:conformsToKnowledgeRepresentationParadigm>
+          <ns2:KnowledgeRepresentationParadigm rdf:about="https://example.org/KnowledgeRepresentationParadigm/KnowledgeRepresentationParadigmID">
+          </ns2:KnowledgeRepresentationParadigm>
+        </ns2:conformsToKnowledgeRepresentationParadigm>
+
+        <ns2:createdProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/createdProperty</ns2:createdProperty>
+        <ns2:definitionProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/definitionProperty</ns2:definitionProperty>
+        <ns2:fairScore rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:fairScore>
+        <ns2:hasFormalityLevel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns2:hasFormalityLevel>
+        <ns2:hasRepresentationLanguage rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Lorem ipsum</ns2:hasRepresentationLanguage>
+        <ns2:hasSyntax rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/hasSyntax</ns2:hasSyntax>
+        <ns2:hierarchyProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/hierarchyProperty</ns2:hierarchyProperty>
+        <ns2:maxChildCount rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:maxChildCount>
+        <ns2:maxDepth rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:maxDepth>
+        <ns2:metadataVoc rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/metadataVoc</ns2:metadataVoc>
+        <ns2:metrics rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:metrics>
+        <ns2:modifiedProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/modifiedProperty</ns2:modifiedProperty>
+        <ns2:numberOfAxioms rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfAxioms>
+        <ns2:numberOfClasses rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</ns2:numberOfClasses>
+        <ns2:numberOfDataProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfDataProperties>
+        <ns2:numberOfDeprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfDeprecated>
+        <ns2:numberOfIndividuals rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfIndividuals>
+        <ns2:numberOfLabels rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfLabels>
+        <ns2:numberOfMappings rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfMappings>
+        <ns2:numberOfObjectProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfObjectProperties>
+        <ns2:numberOfProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfProperties>
+        <ns2:obsoleteParent rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/obsoleteParent</ns2:obsoleteParent>
+        <ns2:obsoleteProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/obsoleteProperty</ns2:obsoleteProperty>
+        <ns2:prefLabelProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/prefLabelProperty</ns2:prefLabelProperty>
+        <ns2:sampleQueries rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/sampleQueries</ns2:sampleQueries>
+        <ns2:synonymProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/synonymProperty</ns2:synonymProperty>
+        <ns2:usedEngineeringMethodology>
+          <ns2:EngineeringMethodology rdf:about="https://example.org/EngineeringMethodology/EngineeringMethodologyID">
+          </ns2:EngineeringMethodology>
+        </ns2:usedEngineeringMethodology>
+
+      </rdf:Description>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/distributions.xml
+++ b/mod_api/static/mod_api/xml/distributions.xml
@@ -111,7 +111,7 @@
         <ns2:metrics rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:metrics>
         <ns2:modifiedProperty rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://example.org/modifiedProperty</ns2:modifiedProperty>
         <ns2:numberOfAxioms rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfAxioms>
-        <ns2:numberOfClasses rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</ns2:numberOfClasses>
+        <ns2:numberOfClasses rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfClasses>
         <ns2:numberOfDataProperties rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfDataProperties>
         <ns2:numberOfDeprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfDeprecated>
         <ns2:numberOfIndividuals rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns2:numberOfIndividuals>

--- a/mod_api/static/mod_api/xml/individuals.xml
+++ b/mod_api/static/mod_api/xml/individuals.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:owl="http://www.w3.org/2002/07/owl#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <owl:NamedIndividual rdf:about="https://example.org/NamedIndividual/NamedIndividualID1">
+      </owl:NamedIndividual>
+    </ns0:member>
+
+    <ns0:member>
+      <owl:NamedIndividual rdf:about="https://example.org/NamedIndividual/NamedIndividualID2">
+      </owl:NamedIndividual>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/properties.xml
+++ b/mod_api/static/mod_api/xml/properties.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <rdfs:Property rdf:about="https://example.org/rdfsProperty/rdfsPropertyID">
+      </rdfs:Property>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/record.xml
+++ b/mod_api/static/mod_api/xml/record.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:ns0="http://purl.org/pav/"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+  <rdf:Description rdf:about="https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID">
+    <rdf:type rdf:resource="https://w3id.org/mod#SemanticArtefactCatalogRecord"/>
+    <dc:conformsTo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:conformsTo>
+    <dc:created rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:created>
+    <dc:dateSubmitted rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:dateSubmitted>
+    <dc:description rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:description>
+    <dc:issued rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:issued>
+    <dc:modified rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:modified>
+    <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
+    <ns0:curatedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns0:curatedBy>
+    <ns0:curatedOn>
+      <xsd:date>
+      </xsd:date>
+    </ns0:curatedOn>
+
+    <foaf:homepage>
+      <foaf:Document rdf:about="https://example.org/Document/DocumentID">
+      </foaf:Document>
+    </foaf:homepage>
+
+    <foaf:primaryTopic>
+      <dcat:Resource rdf:about="https://example.org/dcatResource/dcatResourceID">
+      </dcat:Resource>
+    </foaf:primaryTopic>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/records.xml
+++ b/mod_api/static/mod_api/xml/records.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:ns1="http://purl.org/pav/"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/"
+         xmlns:dcat="http://www.w3.org/ns/dcat#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <rdf:Description rdf:about="https://example.org/SemanticArtefactCatalogRecord/SemanticArtefactCatalogRecordID">
+        <rdf:type rdf:resource="https://w3id.org/mod#SemanticArtefactCatalogRecord"/>
+        <dc:conformsTo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</dc:conformsTo>
+        <dc:created rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:created>
+        <dc:dateSubmitted rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:dateSubmitted>
+        <dc:description rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:description>
+        <dc:issued rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:issued>
+        <dc:modified rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:modified>
+        <dc:title rdf:datatype="http://www.w3.org/2000/01/rdf-schema#Literal">Lorem ipsum</dc:title>
+        <ns1:curatedBy rdf:datatype="http://www.w3.org/2001/XMLSchema#string">string</ns1:curatedBy>
+        <ns1:curatedOn>
+          <xsd:date>
+          </xsd:date>
+        </ns1:curatedOn>
+
+        <foaf:homepage>
+          <foaf:Document rdf:about="https://example.org/Document/DocumentID">
+          </foaf:Document>
+        </foaf:homepage>
+
+        <foaf:primaryTopic>
+          <dcat:Resource rdf:about="https://example.org/dcatResource/dcatResourceID">
+          </dcat:Resource>
+        </foaf:primaryTopic>
+
+      </rdf:Description>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/resource.xml
+++ b/mod_api/static/mod_api/xml/resource.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+  <rdfs:Resource rdf:about="https://example.org/Resource/ResourceID">
+  </rdfs:Resource>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/resources.xml
+++ b/mod_api/static/mod_api/xml/resources.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <rdfs:Resource rdf:about="https://example.org/Resource/ResourceID">
+      </rdfs:Resource>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>

--- a/mod_api/static/mod_api/xml/schemes.xml
+++ b/mod_api/static/mod_api/xml/schemes.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:ns0="http://www.w3.org/ns/hydra/core#"
+         xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+
+  <rdf:Description rdf:about="https://example.org/collection/collectionID">
+    <rdf:type rdf:resource="http://www.w3.org/ns/hydra/core#Collection"/>
+    <ns0:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">50</ns0:itemsPerPage>
+    <ns0:member>
+      <skos:ConceptScheme rdf:about="https://example.org/skosScheme/skosSchemeID1">
+        <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cars scheme</skos:prefLabel>
+      </skos:ConceptScheme>
+    </ns0:member>
+
+    <ns0:member>
+      <skos:ConceptScheme rdf:about="https://example.org/skosScheme/skosSchemeID2">
+        <skos:prefLabel rdf:datatype="http://www.w3.org/2001/XMLSchema#string">cats scheme</skos:prefLabel>
+      </skos:ConceptScheme>
+    </ns0:member>
+
+    <ns0:totalItems rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">5436</ns0:totalItems>
+    <ns0:view>
+      <ns0:PartialCollectionView rdf:about="https://example.org/items?page=3">
+        <ns0:first rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=1</ns0:first>
+        <ns0:last rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=42</ns0:last>
+        <ns0:next rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=4</ns0:next>
+        <ns0:previous rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://example.org/items?page=2</ns0:previous>
+      </ns0:PartialCollectionView>
+    </ns0:view>
+
+  </rdf:Description>
+
+</rdf:RDF>


### PR DESCRIPTION
Make use of 'examples' in the yaml file to provide the updated examples. This also allows the ability to provide multiple examples, i.e. for search results. #15

Rather than being generated from the component parts, the updated examples are provided as blocks of json.

The updated examples are also provided as 'ttl' and 'xml'. These were generated from the json examples.

Updated examples are provided for:
- /
- /artefacts
- /artefacts/{artefactID}
- /artefacts/{artefactID}/distributions
- /artefacts/{artefactID}/distributions/{distributionID}
- /artefacts/{artefactID}/distributions/latest
- /artefacts/{artefactID}/record
- /artefacts/{artefactID}/resources
- /artefacts/{artefactID}/resources/{resourceID}
- /artefacts/{artefactID}/resources/classes
- /artefacts/{artefactID}/resources/concepts
- /artefacts/{artefactID}/resources/properties
- /artefacts/{artefactID}/resources/individuals
- /artefacts/{artefactID}/resources/schemes
- /artefacts/{artefactID}/resources/collections
- /records
- /records/{artefactID}
- /search
- /search/content
- /search/metadata

Fix issue with dcat:Distribution importing dcat:DataService rather than
pointing to it.

Fix issue with dcat:CatalogRecord importing dcat:Resource rather than
pointing to it.

Fix issue with dcat:Catalog importing dcat:Dataset, dcat:Resource,
dcat:CatalogRecord and dcat:DataServicerather than
pointing to them.

Other changes:
- the type of qualifiedRelation has changed from a string to a
dcat:Relationship
- the use of dcterms:subject has been replaced with dcat:theme in the
SemanticArtefact

For the updated examples the prefixes have been removed #24.

Additionally '@id' was added to:
- skos:Collection
- skos:Concept
- skos:ConceptScheme